### PR TITLE
Fix #11 by using hardcoded float for bounds check

### DIFF
--- a/epsilon/simd.go
+++ b/epsilon/simd.go
@@ -2269,7 +2269,10 @@ func saturateF32toInt32(f float32) int32 {
 	if math.IsNaN(float64(f)) {
 		return 0
 	}
-	if f > math.MaxInt32 {
+
+	// We use an explicit float rather than comparing against math.MaxInt32
+	// to avoid subtle differences in behavior between architectures.
+	if f >= 2147483648.0 {
 		return math.MaxInt32
 	}
 	if f < math.MinInt32 {


### PR DESCRIPTION
Comparing `float32` vs `untyped int` behaves differently in amd64 vs arm64. Explicitly using a float fixes the issue. 