### PR TITLE
[Experimental] Propagate ctx to be able to cancel long executions

### DIFF
--- a/epsilon/instance.go
+++ b/epsilon/instance.go
@@ -14,6 +14,8 @@
 
 package epsilon
 
+import "context"
+
 // exportInstance represents the runtime representation of an export.
 type exportInstance struct {
 	name  string
@@ -37,8 +39,12 @@ type ModuleInstance struct {
 //
 // Args can be int32, int64, float32, or float64. The function returns a slice
 // of results as []any, which can be type-asserted to the appropriate types.
-func (m *ModuleInstance) Invoke(name string, args ...any) ([]any, error) {
-	return m.vm.invoke(m, name, args...)
+func (m *ModuleInstance) Invoke(
+	ctx context.Context,
+	name string,
+	args ...any,
+) ([]any, error) {
+	return m.vm.invoke(ctx, m, name, args...)
 }
 
 // GetMemory returns an exported memory by name.

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -16,6 +16,7 @@ package epsilon
 
 import (
 	"bytes"
+	"context"
 	"io"
 )
 
@@ -36,13 +37,17 @@ func (r *Runtime) WithFeatures(features ExperimentalFeatures) *Runtime {
 }
 
 // InstantiateModule parses and instantiates a WASM module from an io.Reader.
-func (r *Runtime) InstantiateModule(wasm io.Reader) (*ModuleInstance, error) {
-	return r.InstantiateModuleWithImports(wasm, nil)
+func (r *Runtime) InstantiateModule(
+	ctx context.Context,
+	wasm io.Reader,
+) (*ModuleInstance, error) {
+	return r.InstantiateModuleWithImports(ctx, wasm, nil)
 }
 
 // InstantiateModuleWithImports parses and instantiates a WASM module with
 // imports.
 func (r *Runtime) InstantiateModuleWithImports(
+	ctx context.Context,
 	wasm io.Reader,
 	imports map[string]map[string]any,
 ) (*ModuleInstance, error) {
@@ -51,15 +56,16 @@ func (r *Runtime) InstantiateModuleWithImports(
 		return nil, err
 	}
 
-	return r.vm.instantiate(module, imports)
+	return r.vm.instantiate(ctx, module, imports)
 }
 
 // InstantiateModuleFromBytes is a convenience method to instantiate a WASM
 // module from a byte slice.
 func (r *Runtime) InstantiateModuleFromBytes(
+	ctx context.Context,
 	data []byte,
 ) (*ModuleInstance, error) {
-	return r.InstantiateModule(bytes.NewReader(data))
+	return r.InstantiateModule(ctx, bytes.NewReader(data))
 }
 
 // ImportBuilder provides a fluent, type-safe API for building import objects

--- a/example/hello/main.go
+++ b/example/hello/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -18,14 +19,16 @@ func main() {
 	}
 
 	// 2. Instantiate the module
-	instance, err := epsilon.NewRuntime().InstantiateModuleFromBytes(wasmBytes)
+	ctx := context.Background()
+	instance, err := epsilon.NewRuntime().
+		InstantiateModuleFromBytes(ctx, wasmBytes)
 	if err != nil {
 		fmt.Println("Error instantiating module:", err)
 		return
 	}
 
 	// 3. Invoke an exported function
-	result, err := instance.Invoke("add", int32(5), int32(37))
+	result, err := instance.Invoke(ctx, "add", int32(5), int32(37))
 	if err != nil {
 		fmt.Println("Error invoking function:", err)
 		return

--- a/internal/benchmarks/benchmark_test.go
+++ b/internal/benchmarks/benchmark_test.go
@@ -15,6 +15,7 @@
 package benchmarks
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -22,13 +23,14 @@ import (
 )
 
 func BenchmarkFactorialRecursive(b *testing.B) {
-	instance, err := instantiate("code/factorial.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/factorial.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fac_recursive", int64(25))
+		_, err := instance.Invoke(ctx, "fac_recursive", int64(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -36,13 +38,14 @@ func BenchmarkFactorialRecursive(b *testing.B) {
 }
 
 func BenchmarkFactorialIterative(b *testing.B) {
-	instance, err := instantiate("code/factorial.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/factorial.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fac_iterative", int64(25))
+		_, err := instance.Invoke(ctx, "fac_iterative", int64(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -50,13 +53,14 @@ func BenchmarkFactorialIterative(b *testing.B) {
 }
 
 func BenchmarkFibonacciRecursive(b *testing.B) {
-	instance, err := instantiate("code/fibonacci.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/fibonacci.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fib_recursive", int32(25))
+		_, err := instance.Invoke(ctx, "fib_recursive", int32(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -64,13 +68,14 @@ func BenchmarkFibonacciRecursive(b *testing.B) {
 }
 
 func BenchmarkFibonacciIterative(b *testing.B) {
-	instance, err := instantiate("code/fibonacci.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/fibonacci.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fib_iterative", int32(25))
+		_, err := instance.Invoke(ctx, "fib_iterative", int32(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -78,13 +83,14 @@ func BenchmarkFibonacciIterative(b *testing.B) {
 }
 
 func BenchmarkIndirect(b *testing.B) {
-	instance, err := instantiate("code/indirect.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/indirect.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("run_indirect_calls", int32(100))
+		_, err := instance.Invoke(ctx, "run_indirect_calls", int32(100))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -92,13 +98,14 @@ func BenchmarkIndirect(b *testing.B) {
 }
 
 func BenchmarkMatrixMultiplication(b *testing.B) {
-	instance, err := instantiate("code/matrix_multiplication.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/matrix_multiplication.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("run_matrix_multiplication", int32(100))
+		_, err := instance.Invoke(ctx, "run_matrix_multiplication", int32(100))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -106,13 +113,14 @@ func BenchmarkMatrixMultiplication(b *testing.B) {
 }
 
 func BenchmarkMemoryAccess(b *testing.B) {
-	instance, err := instantiate("code/memory_access.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/memory_access.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("run_memcpy", int32(100))
+		_, err := instance.Invoke(ctx, "run_memcpy", int32(100))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -120,13 +128,14 @@ func BenchmarkMemoryAccess(b *testing.B) {
 }
 
 func BenchmarkTrigonometrySin(b *testing.B) {
-	instance, err := instantiate("code/trigonometry.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/trigonometry.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("compute_sin", float32(42.7))
+		_, err := instance.Invoke(ctx, "compute_sin", float32(42.7))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -134,13 +143,14 @@ func BenchmarkTrigonometrySin(b *testing.B) {
 }
 
 func BenchmarkSortingBubbleSort(b *testing.B) {
-	instance, err := instantiate("code/sorting.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/sorting.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("bubble_sort")
+		_, err := instance.Invoke(ctx, "bubble_sort")
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -148,13 +158,14 @@ func BenchmarkSortingBubbleSort(b *testing.B) {
 }
 
 func BenchmarkSortingMergeSort(b *testing.B) {
-	instance, err := instantiate("code/sorting.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/sorting.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("merge_sort")
+		_, err := instance.Invoke(ctx, "merge_sort")
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -162,23 +173,27 @@ func BenchmarkSortingMergeSort(b *testing.B) {
 }
 
 func BenchmarkSortingQuickSort(b *testing.B) {
-	instance, err := instantiate("code/sorting.wasm")
+	ctx := context.Background()
+	instance, err := instantiate(ctx, "code/sorting.wasm")
 	if err != nil {
 		b.Fatalf("failed to initialize test: %v", err)
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("quick_sort")
+		_, err := instance.Invoke(ctx, "quick_sort")
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
 	}
 }
 
-func instantiate(wasmPath string) (*epsilon.ModuleInstance, error) {
+func instantiate(
+	ctx context.Context,
+	wasmPath string,
+) (*epsilon.ModuleInstance, error) {
 	wasm, err := os.ReadFile(wasmPath)
 	if err != nil {
 		return nil, err
 	}
-	return epsilon.NewRuntime().InstantiateModuleFromBytes(wasm)
+	return epsilon.NewRuntime().InstantiateModuleFromBytes(ctx, wasm)
 }


### PR DESCRIPTION
Not sure this is worth it (though we can probably optimize this further):

# Benchmark: `main` vs `context`

| Benchmark | Time (ns/op) | Δ | Memory (B/op) | Δ | Allocs | Δ |
|-----------|--------------|---|---------------|---|--------|---|
| FactorialIterative | 1,877 → 2,001 | 🔴 +6.61% | 816 → 816 | ⚪ +0.00% | 36 → 36 | ⚪ +0.00% |
| FactorialRecursive | 2,065 → 2,137 | 🔴 +3.49% | 944 → 944 | ⚪ +0.00% | 42 → 42 | ⚪ +0.00% |
| FibonacciIterative | 1,534 → 1,641 | 🔴 +6.98% | 748 → 748 | ⚪ +0.00% | 29 → 29 | ⚪ +0.00% |
| FibonacciRecursive | 40,221,016 → 42,462,302 | 🔴 +5.57% | 39,999,772 → 39,999,786 | ⚪ +0.00% | 1,244,505 → 1,244,505 | ⚪ +0.00% |
| Indirect | 20,837 → 21,830 | 🔴 +4.77% | 21,444 → 21,444 | ⚪ +0.00% | 814 → 814 | ⚪ +0.00% |
| MatrixMultiplication | 5,625,584,417 → 5,902,461,333 | 🔴 +4.92% | 754,563,576 → 754,563,448 | ⚪ -0.00% | 183,968,060 → 183,968,059 | ⚪ -0.00% |
| MemoryAccess | 2,362,488,625 → 2,494,781,500 | 🔴 +5.60% | 234,882,120 → 234,882,136 | ⚪ +0.00% | 58,720,311 → 58,720,311 | ⚪ +0.00% |
| SortingBubbleSort | 1,094,911 → 1,179,083 | 🔴 +7.69% | 503,616 → 503,617 | ⚪ +0.00% | 14,647 → 14,648 | ⚪ +0.01% |
| SortingMergeSort | 984,167 → 1,021,276 | 🔴 +3.77% | 786,451 → 786,451 | ⚪ +0.00% | 22,250 → 22,250 | ⚪ +0.00% |
| SortingQuickSort | 1,662,925 → 1,753,790 | 🔴 +5.46% | 383,140 → 383,125 | ⚪ -0.00% | 22,519 → 22,518 | ⚪ -0.00% |
| TrigonometrySin | 3,080 → 3,242 | 🔴 +5.26% | 2,968 → 2,968 | ⚪ +0.00% | 116 → 116 | ⚪ +0.00% |