### PR TITLE
Unify vm access to the current callFrame

### DIFF
--- a/epsilon/imports.go
+++ b/epsilon/imports.go
@@ -93,7 +93,7 @@ func resolveFunctionImport(
 	imp moduleImport,
 ) (FunctionInstance, error) {
 	if f, ok := obj.(FunctionInstance); ok {
-		if !f.GetType().Equal(&functionType) {
+		if !f.GetType().Equal(functionType) {
 			return nil, fmt.Errorf(
 				"type mismatch for %s.%s", imp.moduleName, imp.name,
 			)

--- a/epsilon/table.go
+++ b/epsilon/table.go
@@ -25,7 +25,7 @@ type Table struct {
 }
 
 // NewTable creates a new Table instance from a TableType.
-// The table is initialized with 'NullReference' elements up to the minimum size.
+// The table is initialized with 'NullReference' elements up to the min size.
 func NewTable(tt TableType) *Table {
 	elements := make([]int32, tt.Limits.Min)
 	for i := range elements {
@@ -68,11 +68,9 @@ func (t *Table) Grow(n int32, val int32) int32 {
 		}
 	}
 
-	newElements := make([]int32, n)
-	for i := range newElements {
-		newElements[i] = val
+	for range n {
+		t.elements = append(t.elements, val)
 	}
-	t.elements = append(t.elements, newElements...)
 
 	return previousSize
 }

--- a/epsilon/types.go
+++ b/epsilon/types.go
@@ -41,9 +41,7 @@ func (NumberType) isValueType() {}
 // See https://webassembly.github.io/spec/core/syntax/types.html#vector-types.
 type VectorType int
 
-const (
-	V128 VectorType = 0x7b
-)
+const V128 VectorType = 0x7b
 
 func (VectorType) isValueType() {}
 
@@ -96,13 +94,7 @@ type FunctionType struct {
 	ResultTypes []ValueType
 }
 
-func (ft *FunctionType) Equal(other *FunctionType) bool {
-	if ft == other {
-		return true
-	}
-	if ft == nil || other == nil {
-		return false
-	}
+func (ft *FunctionType) Equal(other FunctionType) bool {
 	return slices.Equal(ft.ParamTypes, other.ParamTypes) &&
 		slices.Equal(ft.ResultTypes, other.ResultTypes)
 }

--- a/epsilon/validation.go
+++ b/epsilon/validation.go
@@ -1144,7 +1144,10 @@ func (v *validator) validateTableGet() error {
 	return v.validateUnaryOp(I32, v.tableTypes[tableIndex].ReferenceType)
 }
 
-func (v *validator) validateSimdExtractLane(rangeVal uint64, scalarType ValueType) error {
+func (v *validator) validateSimdExtractLane(
+	rangeVal uint64,
+	scalarType ValueType,
+) error {
 	laneIndex := v.next()
 	if laneIndex >= rangeVal {
 		return errSimdLaneIndexOutOfBounds
@@ -1152,7 +1155,10 @@ func (v *validator) validateSimdExtractLane(rangeVal uint64, scalarType ValueTyp
 	return v.validateUnaryOp(V128, scalarType)
 }
 
-func (v *validator) validateSimdReplaceLane(rangeVal uint64, scalarType ValueType) error {
+func (v *validator) validateSimdReplaceLane(
+	rangeVal uint64,
+	scalarType ValueType,
+) error {
 	laneIndex := v.next()
 	if laneIndex >= rangeVal {
 		return errSimdLaneIndexOutOfBounds

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -1347,7 +1347,7 @@ func (vm *vm) handleCallIndirect(frame *callFrame) error {
 	}
 
 	function := vm.store.funcs[uint32(tableElement)]
-	if !function.GetType().Equal(&expectedType) {
+	if !function.GetType().Equal(expectedType) {
 		return fmt.Errorf("indirect call type mismatch")
 	}
 


### PR DESCRIPTION
This PR introduces some more performance improvements:


| Benchmark            | Time (ns/op)                  | Δ        | Memory (B/op) | Δ        | Allocs | Δ        |
|----------------------|-------------------------------|----------|---------------|----------|--------|----------|
| FactorialIterative   | 683 → 636                     | 🟢 -6.88% | 24 → 24       | ⚪ +0.00% | 2 → 2  | ⚪ +0.00% |
| FactorialRecursive   | 748 → 700                     | 🟢 -6.37% | 24 → 24       | ⚪ +0.00% | 2 → 2  | ⚪ +0.00% |
| FibonacciIterative   | 549 → 513                     | 🟢 -6.54% | 20 → 20       | ⚪ +0.00% | 2 → 2  | ⚪ +0.00% |
| FibonacciRecursive   | 11,695,435 → 11,097,889       | 🟢 -5.11% | 20 → 20       | ⚪ +0.00% | 2 → 2  | ⚪ +0.00% |
| Indirect             | 6,165 → 5,908                 | 🟢 -4.17% | 20 → 20       | ⚪ +0.00% | 2 → 2  | ⚪ +0.00% |
| MatrixMultiplication | 1,937,301,542 → 1,813,799,542 | 🟢 -6.37% | 272 → 272     | ⚪ +0.00% | 3 → 3  | ⚪ +0.00% |
| MemoryAccess         | 780,699,812 → 727,696,812     | 🟢 -6.79% | 16 → 16       | ⚪ +0.00% | 1 → 1  | ⚪ +0.00% |
| SortingBubbleSort    | 396,334 → 362,246             | 🟢 -8.60% | 0 → 0         | ⚪ +0.00% | 0 → 0  | ⚪ +0.00% |
| SortingMergeSort     | 331,400 → 316,798             | 🟢 -4.41% | 0 → 0         | ⚪ +0.00% | 0 → 0  | ⚪ +0.00% |
| SortingQuickSort     | 617,070 → 587,550             | 🟢 -4.78% | 0 → 0         | ⚪ +0.00% | 0 → 0  | ⚪ +0.00% |
| TrigonometrySin      | 969 → 917                     | 🟢 -5.37% | 468 → 468     | ⚪ +0.00% | 3 → 3  | ⚪ +0.00% |