### PR TITLE
Context-aware host functions and import API refactor

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,9 @@ jobs:
         tar -xzf wabt-1.0.39-linux-x64.tar.gz 
         echo "$(pwd)/wabt-1.0.39/bin" >> $GITHUB_PATH 
     - name: Build
-      run: go build ./...
+      run: |
+        go build ./...
+        GOOS=darwin go build -o epsilon-darwin ./cmd/epsilon
+        GOOS=windows go build -o epsilon.exe ./cmd/epsilon
     - name: Test
       run: go test ./...

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Extend your WebAssembly modules with custom Go functions and more using
 
 ```go
 // Create imports before instantiation
-imports := epsilon.NewImportBuilder().
-	AddHostFunc("env", "log", func(args ...any) []any {
+imports := epsilon.NewModuleImportBuilder("env").
+	AddHostFunc("log", func(m *epsilon.ModuleInstance, args ...any) []any {
 		fmt.Printf("[WASM Log]: %v\n", args[0])
 		return nil
 	}).
@@ -77,7 +77,7 @@ imports := epsilon.NewImportBuilder().
 
 // Instantiate with imports
 instance, _ := epsilon.NewRuntime().
-	InstantiateModuleWithImports(wasmFile, imports)
+	InstantiateModuleWithImports(bytes.NewReader(wasmBytes), imports)
 ```
 
 ## CLI

--- a/epsilon/instance.go
+++ b/epsilon/instance.go
@@ -138,7 +138,8 @@ func (wf *wasmFunction) GetType() *FunctionType { return &wf.functionType }
 // hostFunction represents a function defined by the host environment.
 type hostFunction struct {
 	functionType FunctionType
-	hostCode     func(...any) []any
+	module       *ModuleInstance
+	hostCode     func(*ModuleInstance, ...any) []any
 }
 
 func (hf *hostFunction) GetType() *FunctionType { return &hf.functionType }

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -163,7 +163,5 @@ func (b *ModuleImportBuilder) AddModuleExports(
 }
 
 func (b *ModuleImportBuilder) Build() map[string]map[string]any {
-	return map[string]map[string]any{
-		b.moduleName: b.imports,
-	}
+	return map[string]map[string]any{b.moduleName: b.imports}
 }

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -89,7 +89,10 @@ func (r *Runtime) ensureVm() {
 // Example:
 //
 //	imports := epsilon.NewModuleImportBuilder("env").
-//	    AddHostFunc("log", func(x int32) { fmt.Println("WASM says:", x) }).
+//	    AddHostFunc("log", func(m *epsilon.ModuleInstance, args ...any) []any {
+//	        fmt.Println("WASM says:", args[0])
+//	        return nil
+//	    }).
 //	    AddMemory("memory", epsilon.NewMemory(epsilon.MemoryType{
 //	        Limits: epsilon.Limits{Min: 1},
 //	    })).

--- a/epsilon/runtime_test.go
+++ b/epsilon/runtime_test.go
@@ -55,8 +55,8 @@ func TestRuntimeImportedFunction(t *testing.T) {
 			call $multiply)
 	)`)
 
-	imports := NewImportBuilder().
-		AddHostFunc("env", "multiply", func(args ...any) []any {
+	imports := NewModuleImportBuilder("env").
+		AddHostFunc("multiply", func(module *ModuleInstance, args ...any) []any {
 			a := args[0].(int32)
 			b := args[1].(int32)
 			return []any{a * b}
@@ -96,8 +96,8 @@ func TestRuntimeImportedMemory(t *testing.T) {
 		t.Fatalf("failed to set memory: %v", err)
 	}
 
-	imports := NewImportBuilder().
-		AddMemory("env", "memory", memory).
+	imports := NewModuleImportBuilder("env").
+		AddMemory("memory", memory).
 		Build()
 
 	instance, err := NewRuntime().
@@ -140,8 +140,8 @@ func TestRuntimeImportedGlobal(t *testing.T) {
 			i32.add)
 	)`)
 
-	imports := NewImportBuilder().
-		AddGlobal("env", "offset", int32(100), false, I32).
+	imports := NewModuleImportBuilder("env").
+		AddGlobal("offset", int32(100), false, I32).
 		Build()
 
 	instance, err := NewRuntime().
@@ -180,12 +180,12 @@ func TestRuntimeImportedFunctionsInTable(t *testing.T) {
 			call_indirect (type $op))
 	)`)
 
-	imports := NewImportBuilder().
-		AddHostFunc("env", "host_sub", func(args ...any) []any {
+	imports := NewModuleImportBuilder("env").
+		AddHostFunc("host_sub", func(module *ModuleInstance, args ...any) []any {
 			x := args[0].(int32)
 			return []any{x - 1}
 		}).
-		AddTable("env", "table", NewTable(TableType{
+		AddTable("table", NewTable(TableType{
 			ReferenceType: FuncRefType,
 			Limits:        Limits{Min: 2},
 		})).
@@ -244,7 +244,7 @@ func TestRuntimeModuleToModuleImport(t *testing.T) {
 
 	module2, err := runtime.InstantiateModuleWithImports(
 		bytes.NewReader(module2Wasm),
-		NewImportBuilder().AddModuleExports("math", module1).Build(),
+		NewModuleImportBuilder("math").AddModuleExports(module1).Build(),
 	)
 	if err != nil {
 		t.Fatalf("failed to instantiate module2: %v", err)

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -103,7 +103,7 @@ func (vm *vm) instantiate(
 		vm:    vm,
 	}
 
-	resolvedImports, err := resolveImports(module, imports)
+	resolvedImports, err := resolveImports(module, moduleInstance, imports)
 	if err != nil {
 		return nil, err
 	}
@@ -1893,7 +1893,7 @@ func (vm *vm) invokeHostFunction(fun *hostFunction) (err error) {
 	}()
 
 	args := vm.stack.popValueTypes(fun.GetType().ParamTypes)
-	res := fun.hostCode(args...)
+	res := fun.hostCode(fun.module, args...)
 	vm.stack.pushAll(res)
 	return err
 }

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -796,7 +796,7 @@ func TestFunctionImport(t *testing.T) {
 	)`
 	imports := map[string]map[string]any{
 		"module": {
-			"sum": func(args ...any) []any {
+			"sum": func(module *ModuleInstance, args ...any) []any {
 				val := args[0].(int32) + args[1].(int32)
 				return []any{val}
 			},

--- a/internal/spec_tests/spec_test_runner.go
+++ b/internal/spec_tests/spec_test_runner.go
@@ -50,14 +50,11 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 			Limits:        epsilon.Limits{Min: 10, Max: &tableLimitMax},
 			ReferenceType: epsilon.FuncRefType,
 		})).
-		AddMemory(
-			"memory",
-			epsilon.NewMemory(
-				epsilon.MemoryType{
-					Limits: epsilon.Limits{Min: 1, Max: &importMemoryLimitMax},
-				},
-			),
-		).
+		AddMemory("memory", epsilon.NewMemory(
+			epsilon.MemoryType{
+				Limits: epsilon.Limits{Min: 1, Max: &importMemoryLimitMax},
+			},
+		)).
 		AddHostFunc(
 			"print_i32",
 			func(m *epsilon.ModuleInstance, args ...any) []any {

--- a/internal/spec_tests/spec_test_runner.go
+++ b/internal/spec_tests/spec_test_runner.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"maps"
 	"math"
 	"strconv"
 	"strings"
@@ -42,17 +41,16 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 	importMemoryLimitMax := uint32(2)
 	tableLimitMax := uint32(20)
 
-	spectestImports := epsilon.NewImportBuilder().
-		AddGlobal("spectest", "global_i32", int32(666), false, epsilon.I32).
-		AddGlobal("spectest", "global_i64", int64(666), false, epsilon.I64).
-		AddGlobal("spectest", "global_f32", float32(666.6), false, epsilon.F32).
-		AddGlobal("spectest", "global_f64", float64(666.6), false, epsilon.F64).
-		AddTable("spectest", "table", epsilon.NewTable(epsilon.TableType{
+	spectestImports := epsilon.NewModuleImportBuilder("spectest").
+		AddGlobal("global_i32", int32(666), false, epsilon.I32).
+		AddGlobal("global_i64", int64(666), false, epsilon.I64).
+		AddGlobal("global_f32", float32(666.6), false, epsilon.F32).
+		AddGlobal("global_f64", float64(666.6), false, epsilon.F64).
+		AddTable("table", epsilon.NewTable(epsilon.TableType{
 			Limits:        epsilon.Limits{Min: 10, Max: &tableLimitMax},
 			ReferenceType: epsilon.FuncRefType,
 		})).
 		AddMemory(
-			"spectest",
 			"memory",
 			epsilon.NewMemory(
 				epsilon.MemoryType{
@@ -60,35 +58,56 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 				},
 			),
 		).
-		AddHostFunc("spectest", "print_i32", func(args ...any) []any {
-			fmt.Printf("%d", args[0].(int32))
-			return nil
-		}).
-		AddHostFunc("spectest", "print_i64", func(args ...any) []any {
-			fmt.Printf("%d", args[0].(int64))
-			return nil
-		}).
-		AddHostFunc("spectest", "print_f32", func(args ...any) []any {
-			fmt.Printf("%f", args[0].(float32))
-			return nil
-		}).
-		AddHostFunc("spectest", "print_f64", func(args ...any) []any {
-			fmt.Printf("%f", args[0].(float64))
-			return nil
-		}).
-		AddHostFunc("spectest", "print_i32_f32", func(args ...any) []any {
-			fmt.Printf("%d %f", args[0].(int32), args[1].(float32))
-			return nil
-		}).
-		AddHostFunc("spectest", "print_i64_f64", func(args ...any) []any {
-			fmt.Printf("%d %f", args[0].(int64), args[1].(float64))
-			return nil
-		}).
-		AddHostFunc("spectest", "print_f64_f64", func(args ...any) []any {
-			fmt.Printf("%f %f", args[0].(float64), args[1].(float64))
-			return nil
-		}).
-		AddHostFunc("spectest", "print", func(args ...any) []any {
+		AddHostFunc(
+			"print_i32",
+			func(m *epsilon.ModuleInstance, args ...any) []any {
+				fmt.Printf("%d", args[0].(int32))
+				return nil
+			},
+		).
+		AddHostFunc(
+			"print_i64",
+			func(m *epsilon.ModuleInstance, args ...any) []any {
+				fmt.Printf("%d", args[0].(int64))
+				return nil
+			},
+		).
+		AddHostFunc(
+			"print_f32",
+			func(m *epsilon.ModuleInstance, args ...any) []any {
+				fmt.Printf("%f", args[0].(float32))
+				return nil
+			},
+		).
+		AddHostFunc(
+			"print_f64",
+			func(m *epsilon.ModuleInstance, args ...any) []any {
+				fmt.Printf("%f", args[0].(float64))
+				return nil
+			},
+		).
+		AddHostFunc(
+			"print_i32_f32",
+			func(m *epsilon.ModuleInstance, args ...any) []any {
+				fmt.Printf("%d %f", args[0].(int32), args[1].(float32))
+				return nil
+			},
+		).
+		AddHostFunc(
+			"print_i64_f64",
+			func(m *epsilon.ModuleInstance, args ...any) []any {
+				fmt.Printf("%d %f", args[0].(int64), args[1].(float64))
+				return nil
+			},
+		).
+		AddHostFunc(
+			"print_f64_f64",
+			func(m *epsilon.ModuleInstance, args ...any) []any {
+				fmt.Printf("%f %f", args[0].(float64), args[1].(float64))
+				return nil
+			},
+		).
+		AddHostFunc("print", func(m *epsilon.ModuleInstance, args ...any) []any {
 			fmt.Printf("Print called!")
 			return nil
 		}).
@@ -151,20 +170,21 @@ func (r *specTestRunner) handleRegister(cmd wabt.Command) {
 	r.moduleInstanceMap[cmd.As] = r.lastModuleInstance
 }
 
-func (r *specTestRunner) buildImports() map[string]map[string]any {
-	builder := epsilon.NewImportBuilder()
+func (r *specTestRunner) buildImports() []map[string]map[string]any {
+	imports := []map[string]map[string]any{r.spectestImports}
 	for regName, moduleInstance := range r.moduleInstanceMap {
-		builder.AddModuleExports(regName, moduleInstance)
+		moduleImport := epsilon.NewModuleImportBuilder(regName).
+			AddModuleExports(moduleInstance).
+			Build()
+		imports = append(imports, moduleImport)
 	}
-	imports := builder.Build()
-	maps.Copy(imports, r.spectestImports)
 	return imports
 }
 
 func (r *specTestRunner) handleModule(cmd wabt.Command) {
-	wasmBytes := r.wasmDict[cmd.Filename]
+	wasm := bytes.NewReader(r.wasmDict[cmd.Filename])
 	instance, err := r.runtime.
-		InstantiateModuleWithImports(bytes.NewReader(wasmBytes), r.buildImports())
+		InstantiateModuleWithImports(wasm, r.buildImports()...)
 	if err != nil {
 		r.fatalf(cmd.Line, "failed to instantiate module %s: %v", cmd.Filename, err)
 	}
@@ -198,9 +218,8 @@ func (r *specTestRunner) handleAssertReturn(cmd wabt.Command) {
 func (r *specTestRunner) handleAssertTrap(cmd wabt.Command) {
 	if cmd.Filename != "" {
 		// This is asserting that instantiating a module will trap.
-		wasmBytes := r.wasmDict[cmd.Filename]
-		_, err := r.runtime.
-			InstantiateModuleWithImports(bytes.NewReader(wasmBytes), r.buildImports())
+		wasm := bytes.NewReader(r.wasmDict[cmd.Filename])
+		_, err := r.runtime.InstantiateModuleWithImports(wasm, r.buildImports()...)
 		if err == nil {
 			r.fatalf(cmd.Line, "expected trap during instantiation, but got no error")
 		}
@@ -214,9 +233,8 @@ func (r *specTestRunner) handleAssertTrap(cmd wabt.Command) {
 }
 
 func (r *specTestRunner) handleAssertInvalid(cmd wabt.Command) {
-	wasmBytes := r.wasmDict[cmd.Filename]
-	_, err := r.runtime.
-		InstantiateModuleWithImports(bytes.NewReader(wasmBytes), r.buildImports())
+	wasm := bytes.NewReader(r.wasmDict[cmd.Filename])
+	_, err := r.runtime.InstantiateModuleWithImports(wasm, r.buildImports()...)
 	if err == nil {
 		r.fatalf(cmd.Line, "expected validation error, but got no error")
 	}
@@ -229,27 +247,24 @@ func (r *specTestRunner) handleAssertMalformed(cmd wabt.Command) {
 		return
 	}
 
-	wasmBytes := r.wasmDict[cmd.Filename]
-	_, err := r.runtime.
-		InstantiateModuleWithImports(bytes.NewReader(wasmBytes), r.buildImports())
+	wasm := bytes.NewReader(r.wasmDict[cmd.Filename])
+	_, err := r.runtime.InstantiateModuleWithImports(wasm, r.buildImports()...)
 	if err == nil {
 		r.fatalf(cmd.Line, "expected validation error, but got no error")
 	}
 }
 
 func (r *specTestRunner) handleAssertUninstantiable(cmd wabt.Command) {
-	wasmBytes := r.wasmDict[cmd.Filename]
-	_, err := r.runtime.
-		InstantiateModuleWithImports(bytes.NewReader(wasmBytes), r.buildImports())
+	wasm := bytes.NewReader(r.wasmDict[cmd.Filename])
+	_, err := r.runtime.InstantiateModuleWithImports(wasm, r.buildImports()...)
 	if err == nil {
 		r.fatalf(cmd.Line, "expected uninstantiable module, it wasn't")
 	}
 }
 
 func (r *specTestRunner) handleAssertUnlinkable(cmd wabt.Command) {
-	wasmBytes := r.wasmDict[cmd.Filename]
-	_, err := r.runtime.
-		InstantiateModuleWithImports(bytes.NewReader(wasmBytes), r.buildImports())
+	wasm := bytes.NewReader(r.wasmDict[cmd.Filename])
+	_, err := r.runtime.InstantiateModuleWithImports(wasm, r.buildImports()...)
 	if err == nil {
 		r.fatalf(cmd.Line, "expected unlinkable module, it wasn't")
 	}


### PR DESCRIPTION
This PR contain API breaking changes:
   * The Go signature for host functions has changed from `func(...any)` to `func(*ModuleInstance, ...any)`. This will allow implementation of host functions to access e.g. the shared `Memory` (which is a necessary prerequisite for WASI support)
   * `InstantiateModuleWithImports` now takes variadic arguments
   * `NewImportBuilder` has been renamed to `NewModuleImportBuilder`