### PR TITLE
Fix stack-related vulnerabilities

### DIFF
--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -318,7 +318,7 @@ func (p *parser) parseFunction() (function, error) {
 
 	return function{
 		locals:        locals,
-		body:          body[:len(body)-1],
+		body:          body,
 		jumpCache:     result.jumpCache,
 		jumpElseCache: result.jumpElseCache,
 	}, nil
@@ -1070,7 +1070,6 @@ func (p *parser) readCode(isEnd func([]uint64) bool) (bytecodeResult, error) {
 		}
 
 		if isEnd != nil && isEnd(bytecode[currentInstructionStart:]) {
-			bytecode = bytecode[:currentInstructionStart]
 			break
 		}
 	}

--- a/epsilon/parser_test.go
+++ b/epsilon/parser_test.go
@@ -64,6 +64,7 @@ func TestParseExportedFunction(t *testing.T) {
 					uint64(localGet), 0,
 					uint64(localGet), 1,
 					uint64(i32Add),
+					uint64(end),
 				},
 				jumpCache:     map[uint32]uint32{},
 				jumpElseCache: map[uint32]uint32{},
@@ -159,7 +160,7 @@ func TestParseActiveElement(t *testing.T) {
 		t.Fatalf("expected table index 0, got %d", element.tableIndex)
 	}
 
-	expectedOffsetExpression := []uint64{uint64(i32Const), 0x0}
+	expectedOffsetExpression := []uint64{uint64(i32Const), 0x0, uint64(end)}
 	if !slices.Equal(element.offsetExpression, expectedOffsetExpression) {
 		t.Fatalf(
 			"expected offset %v, got %v",
@@ -216,7 +217,7 @@ func TestParseGlobalVariable(t *testing.T) {
 		)
 	}
 
-	expectedInitExpression := []uint64{uint64(i32Const), 42}
+	expectedInitExpression := []uint64{uint64(i32Const), 42, uint64(end)}
 	if !slices.Equal(globalVar.initExpression, expectedInitExpression) {
 		t.Errorf(
 			"expected init expression %v, got %v",
@@ -251,7 +252,7 @@ func TestParseImmutableGlobalVariable(t *testing.T) {
 		)
 	}
 
-	expectedInitExpression := []uint64{uint64(i32Const), 63}
+	expectedInitExpression := []uint64{uint64(i32Const), 63, uint64(end)}
 	if !slices.Equal(globalVar.initExpression, expectedInitExpression) {
 		t.Errorf(
 			"expected init expression %v, got %v",
@@ -397,7 +398,7 @@ func TestParseActiveDataSegment(t *testing.T) {
 	if data.memoryIndex != 0 {
 		t.Fatalf("expected memory index 0, got %d", data.memoryIndex)
 	}
-	expectedOffsetExpression := []uint64{uint64(i32Const), 0x0}
+	expectedOffsetExpression := []uint64{uint64(i32Const), 0x0, uint64(end)}
 	if !slices.Equal(data.offsetExpression, expectedOffsetExpression) {
 		t.Fatalf(
 			"expected offset expression %v, got %v",
@@ -429,7 +430,7 @@ func TestParseActiveDataSegmentWithMemoryIndex(t *testing.T) {
 	if data.memoryIndex != 0 {
 		t.Fatalf("expected memory index 0, got %d", data.memoryIndex)
 	}
-	expectedOffsetExpression := []uint64{uint64(i32Const), 0x0}
+	expectedOffsetExpression := []uint64{uint64(i32Const), 0x0, uint64(end)}
 	if !slices.Equal(data.offsetExpression, expectedOffsetExpression) {
 		t.Fatalf(
 			"expected offset expression %v, got %v",

--- a/epsilon/validation.go
+++ b/epsilon/validation.go
@@ -317,14 +317,6 @@ func (v *validator) validateFunction(function *function) error {
 		}
 	}
 
-	// The parser strips the trailing End instruction from the function body,
-	// but we still need to validate that the control frame is properly closed.
-	// We don't call validateEnd() here because that would push endTypes onto
-	// the stack, which is only needed for nested blocks.
-	_, err := v.popControlFrame()
-	if err != nil {
-		return err
-	}
 	if len(v.controlStack) != 0 {
 		return errUnclosedControlFrame
 	}
@@ -364,10 +356,10 @@ func (v *validator) validateConstExpression(
 		}
 	}
 
-	// Same as validateFunction, we are working around the fact the parser
-	// strips the trailing End instruction from the function body.
-	_, err := v.popControlFrame()
-	return err
+	if len(v.controlStack) != 0 {
+		return errUnclosedControlFrame
+	}
+	return nil
 }
 
 func (v *validator) isConstantOpcode(op opcode) bool {
@@ -386,7 +378,8 @@ func (v *validator) isConstantOpcode(op opcode) bool {
 		op == f64Const ||
 		op == v128Const ||
 		op == refNull ||
-		op == refFunc
+		op == refFunc ||
+		op == end
 }
 
 func (v *validator) validate(op opcode) error {

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -1284,7 +1284,7 @@ func (vm *vm) pushBlockFrame(frame *callFrame, opcode opcode) {
 	vm.pushControlFrame(frame, controlFrame{
 		isLoop:         opcode == loop,
 		blockType:      blockType,
-		stackHeight:    vm.stack.size(),
+		stackHeight:    vm.stack.size() - vm.getInputCount(frame.module, blockType),
 		continuationPc: continuationPc,
 	})
 }

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -28,9 +28,6 @@ var (
 	errIndirectCallTypeMismatch = errors.New("indirect call type mismatch")
 )
 
-// Special error to signal a return instruction was hit.
-var errReturn = errors.New("return instruction")
-
 const (
 	controlStackCacheSlotSize = 14 // Control stack slot size per call frame.
 	localsCacheSlotSize       = 12 // Locals slot size per call frame.
@@ -306,9 +303,6 @@ func (vm *vm) runLoop() error {
 			break
 		}
 		if err := vm.executeInstruction(frame); err != nil {
-			if errors.Is(err, errReturn) {
-				break
-			}
 			vm.callStack = vm.callStack[:len(vm.callStack)-1]
 			return err
 		}
@@ -330,9 +324,6 @@ func (vm *vm) runLoopWithFuel() error {
 		}
 		vm.fuel--
 		if err := vm.executeInstruction(frame); err != nil {
-			if errors.Is(err, errReturn) {
-				break
-			}
 			vm.callStack = vm.callStack[:len(vm.callStack)-1]
 			return err
 		}
@@ -366,7 +357,11 @@ func (vm *vm) executeInstruction(frame *callFrame) error {
 	case brTable:
 		vm.handleBrTable(frame)
 	case returnOp:
-		err = errReturn
+		// Semantically, a return is equivalent to a branch to the outermost block
+		// of the function. By branching to label N-1 (where N is the depth of the
+		// control stack), we trigger a stack unwind to the function's base height
+		// and jump to the 'end' instruction at the end of the function body.
+		vm.brToLabel(frame, uint32(len(frame.controlStack)-1))
 	case call:
 		err = vm.handleCall(frame)
 	case callIndirect:
@@ -1950,7 +1945,10 @@ func (vm *vm) invokeExpression(
 			ParamTypes:  []ValueType{},
 			ResultTypes: []ValueType{resultType},
 		},
-		code:   function{body: expression},
+		code: function{
+			body:      expression,
+			typeIndex: 0xffffffff, // Represents -1. See getOutputCount.
+		},
 		module: moduleInstance,
 	}
 	if err := vm.invokeWasmFunction(&function); err != nil {

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -1074,3 +1074,60 @@ func TestFuelDisabled(t *testing.T) {
 		t.Fatalf("expected 42, got %v", result[0])
 	}
 }
+
+func TestReturnUnwind(t *testing.T) {
+	wat := `(module
+		(func $malicious (result i32)
+			i32.const 1337
+			i32.const 42
+			return)
+		(func (export "test") (result i32)
+			i32.const 10
+			call $malicious
+			drop)
+	)`
+
+	moduleInstance, err := instantiate(wat, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create vm: %v", err)
+	}
+
+	result, err := moduleInstance.Invoke("test")
+	if err != nil {
+		t.Fatalf("failed to execute function: %v", err)
+	}
+
+	observedValue := result[0].(int32)
+	if observedValue != 10 {
+		t.Errorf("expected 10, got %d", observedValue)
+	}
+}
+
+func TestBlockParamUnwind(t *testing.T) {
+	wat := `(module
+		(type $multi (func (param i32 i32) (result i32)))
+		(func (export "test") (result i32)
+			i32.const 10
+			i32.const 20
+			i32.const 30
+			block (type $multi)
+				i32.add
+			end
+			drop)
+	)`
+
+	moduleInstance, err := instantiate(wat, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create vm: %v", err)
+	}
+
+	result, err := moduleInstance.Invoke("test")
+	if err != nil {
+		t.Fatalf("failed to execute function: %v", err)
+	}
+
+	observedValue := result[0].(int32)
+	if observedValue != 10 {
+		t.Errorf("expected 10, got %d", observedValue)
+	}
+}


### PR DESCRIPTION
_Written by Gemini and Claude_

### VULN-01 · Stack Corruption via `return` Instruction

| Field | Value |
|-------|-------|
| **Severity** | Critical |
| **Component** | `epsilon/vm.go` |
| **Impact** | Stack data injection, logic corruption, potential sandbox escape |

#### Description

The `return` instruction does not unwind the value stack to the function's entry height. It simply signals the VM to stop executing the current frame without cleaning up intermediate values. A function can therefore leave "garbage" on the stack, which subsequent instructions in the caller's context will consume as if they were legitimate values.

#### Root Cause

```go
// epsilon/vm.go
case returnOp:
    err = errReturn
```

The `runLoop` function catches `errReturn` and breaks, but never calls `vm.stack.unwind` for the function's initial control frame.

#### Example (WAT)

```wasm
(module
  (func $malicious (result i32)
    i32.const 1337  ;; extra value — should be cleaned on return
    i32.const 42    ;; declared return value
    return)

  (func (export "test") (result i32)
    i32.const 10
    call $malicious  ;; returns 42, but 1337 remains on stack
    drop             ;; drops 42
    ;; Caller expects 10 on top — but gets 1337 instead
  )
)
```

#### Remediation

After `errReturn` is caught, call `vm.stack.unwind(callFrame.stackHeight, outputCount)` to restore the stack to the function's entry height plus its declared return values.

---

### VULN-02 · Stack Corruption via Block Parameters (Multi-Value)

| Field | Value |
|-------|-------|
| **Severity** | Critical |
| **Component** | `epsilon/vm.go` — `pushBlockFrame`, `unwind` |
| **Impact** | Type confusion, forged `funcref`, arbitrary private function calls |

#### Description

When a control-flow block (`block`, `loop`, `if`) takes parameters, the VM captures the stack height *after* the parameters are already on the stack. When the block ends, `unwind` restores the stack to that height — effectively "reviving" values that should have been consumed.

This desynchronizes the VM stack from the validator's view, enabling **type confusion**: an `i32` value can be placed where the validator expects a `funcref`, allowing an attacker to forge function references and call any function in the store.

> [!IMPORTANT]
> This vulnerability and VULN-01 share the same root cause in the `unwind` logic and should be fixed together.

#### Root Cause

```go
// epsilon/vm.go
func (vm *vm) pushBlockFrame(frame *callFrame, opcode opcode) {
    vm.pushControlFrame(frame, controlFrame{
        stackHeight: vm.stack.size(), // includes block parameters
    })
}

// epsilon/value_stack.go
func (s *valueStack) unwind(targetHeight, preserveCount uint32) {
    valuesToPreserve := s.data[s.size()-preserveCount:]
    s.data = s.data[:targetHeight]  // if targetHeight > current size, exposes stale data
    s.data = append(s.data, valuesToPreserve...)
}
```

If `targetHeight` exceeds the current stack size (because the block consumed its parameters), the slice expression extends into the underlying array, exposing stale values.

#### Example — Type Confusion & Private Function Call (WAT)

```wasm
(module
  (type $t (func (result i32)))
  (func $secret (result i32) i32.const 1337)  ;; store index 0

  (table 1 funcref)

  (func (export "attack") (param $idx i32) (result i32)
    (local $f funcref)

    ref.null func              ;; validator: [funcref]

    local.get $idx
    block (param i32)          ;; VM captures height including the i32
      drop
    end
    ;; VM stack: [null, $idx]  — $idx was revived by unwind
    ;; Validator:  [funcref]   — still thinks only null is there

    local.set $f               ;; VM stores $idx (i32) as funcref!

    i32.const 0
    local.get $f
    table.set 0                ;; inject forged funcref into table

    i32.const 0
    call_indirect (type $t)    ;; calls $secret via forged index
  )
)
```

Invoking `attack(0)` returns `1337` — the private function was called.

#### Remediation

When entering a block with parameters, subtract the parameter count from the captured `stackHeight`:

```go
stackHeight: vm.stack.size() - uint32(len(paramTypes))
```
