### PR TITLE
Prevent accessing unexported functions via funcref arguments

### DIFF
--- a/epsilon/instance.go
+++ b/epsilon/instance.go
@@ -17,6 +17,7 @@ package epsilon
 import (
 	"errors"
 	"fmt"
+	"slices"
 )
 
 var errExportNotFound = errors.New("export not found")
@@ -49,7 +50,31 @@ func (m *ModuleInstance) Invoke(name string, args ...any) ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := m.validateRefArgs(function.GetType(), args); err != nil {
+		return nil, err
+	}
 	return m.vm.invoke(function, args)
+}
+
+func (m *ModuleInstance) validateRefArgs(
+	funcType *FunctionType,
+	args []any,
+) error {
+	for i, paramType := range funcType.ParamTypes {
+		if paramType != FuncRefType {
+			continue
+		}
+		idx, ok := args[i].(int32)
+		if !ok || idx == NullReference {
+			continue
+		}
+		// BinarySearch is safe here because funcAddrs is strictly increasing by
+		// construction as functions are sequentially appended during instantiation.
+		if _, found := slices.BinarySearch(m.funcAddrs, uint32(idx)); !found {
+			return fmt.Errorf("funcref at parameter %d is inaccessible", i)
+		}
+	}
+	return nil
 }
 
 // GetMemory returns an exported memory by name.

--- a/epsilon/runtime_test.go
+++ b/epsilon/runtime_test.go
@@ -270,3 +270,45 @@ func TestRuntimeModuleToModuleImport(t *testing.T) {
 		t.Fatalf("expected %d, got %d", expected, results[0])
 	}
 }
+
+func TestInvokeFuncrefInjectionIsRejected(t *testing.T) {
+	// Module A has a private function $secret that is NOT exported.
+	wasmA, _ := wabt.Wat2Wasm(`(module
+		(func $secret (result i32) i32.const 42)
+		(func (export "nop"))
+	)`)
+
+	// Module B accepts a funcref, puts it in a table, and calls it.
+	wasmB, _ := wabt.Wat2Wasm(`(module
+		(table $t 1 funcref)
+		(type $void_to_i32 (func (result i32)))
+		(func (export "exploit") (param $f funcref) (result i32)
+			(table.set $t (i32.const 0) (local.get $f))
+			(call_indirect $t (type $void_to_i32) (i32.const 0)))
+	)`)
+
+	runtime := NewRuntime()
+	_, err := runtime.InstantiateModule(bytes.NewReader(wasmA))
+	if err != nil {
+		t.Fatalf("failed to instantiate Module A: %v", err)
+	}
+
+	moduleB, err := runtime.InstantiateModule(bytes.NewReader(wasmB))
+	if err != nil {
+		t.Fatalf("failed to instantiate Module B: %v", err)
+	}
+
+	// Attempt to inject store index 0 (Module A's private $secret) as a
+	// funcref into Module B. This should be rejected.
+	_, err = moduleB.Invoke("exploit", int32(0))
+	if err == nil {
+		t.Fatal("expected error injecting funcref to inaccessible function")
+	}
+
+	// Null references should still be allowed (they'll trap at call_indirect,
+	// not at the validation boundary).
+	_, err = moduleB.Invoke("exploit", NullReference)
+	if err == nil {
+		t.Fatal("expected trap from call_indirect with null reference")
+	}
+}


### PR DESCRIPTION
_Written by Gemini and Claude_

### VULN-03 · Funcref Injection via Host API

| Field | Value |
|-------|-------|
| **Severity** | Critical |
| **Component** | `epsilon/vm.go` — `Invoke`, `call_indirect` |
| **Impact** | Cross-module private function calls, privilege escalation |

#### Description

`funcref` values are internally represented as `int32` indices into the global `vm.store.funcs` slice. The host `Invoke` API allows passing raw `int32` values to functions expecting `funcref` parameters without validating that the index belongs to the calling module's scope. The `call_indirect` implementation only checks type signature — not module authorization.

#### Example (WAT)

```wasm
;; Module A — has a private function $secret (not exported)
(module
  (func $secret (result i32) i32.const 42)
  (func (export "nop"))
)

;; Module B — receives a funcref, puts it in a table, and calls it
(module
  (table $t 1 funcref)
  (type $void_to_i32 (func (result i32)))
  (func (export "exploit") (param $f funcref) (result i32)
    (table.set $t (i32.const 0) (local.get $f))
    (call_indirect $t (type $void_to_i32) (i32.const 0))
  )
)
```

```go
// Host code — both modules in the same Runtime
r := epsilon.NewRuntime()
r.InstantiateModule(wasmA)       // $secret is at store index 0
m2, _ := r.InstantiateModule(wasmB)
results, _ := m2.Invoke("exploit", int32(0))  // passes store index as funcref
// results[0] == 42 — Module A's private function was called
```

#### Remediation

Validate `funcref` values passed through the host API against the target module's function index space.