### PR TITLE
Prevent forbidden cross-runtime function imports

### DIFF
--- a/epsilon/imports.go
+++ b/epsilon/imports.go
@@ -101,6 +101,19 @@ func resolveFunctionImport(
 				"type mismatch for %s.%s", imp.moduleName, imp.name,
 			)
 		}
+
+		// Prevent cross-runtime function sharing. The WebAssembly spec assumes a
+		// single Store per abstract machine. Mixing objects across Runtimes breaks
+		// isolation and is forbidden.
+		if wasmFn, isWasm := f.(*wasmFunction); isWasm {
+			if wasmFn.module.vm != moduleInstance.vm {
+				return nil, fmt.Errorf(
+					"cross-runtime function import of %s.%s is forbidden",
+					imp.moduleName, imp.name,
+				)
+			}
+		}
+
 		return f, nil
 	}
 

--- a/epsilon/runtime_test.go
+++ b/epsilon/runtime_test.go
@@ -312,3 +312,50 @@ func TestInvokeFuncrefInjectionIsRejected(t *testing.T) {
 		t.Fatal("expected trap from call_indirect with null reference")
 	}
 }
+
+func TestRuntimeConfusion(t *testing.T) {
+	// 1. Create two completely isolated Runtimes
+	r1 := NewRuntime()
+	r2 := NewRuntime()
+
+	// 2. Instantiate Module A in Runtime 1
+	wasmA, _ := wabt.Wat2Wasm(`(module
+		(func $secret (result i32) i32.const 42)
+		(func (export "wrapper") (result i32) call $secret)
+	)`)
+	modA, err := r1.InstantiateModule(bytes.NewReader(wasmA))
+	if err != nil {
+		t.Fatalf("failed to instantiate Module A: %v", err)
+	}
+
+	// 3. Instantiate Module B in Runtime 2
+	wasmB, _ := wabt.Wat2Wasm(`(module
+		(func $secret2 (result i32) i32.const 1337)
+		(export "unused" (func $secret2))
+	)`)
+	_, err = r2.InstantiateModule(bytes.NewReader(wasmB))
+	if err != nil {
+		t.Fatalf("failed to instantiate Module B: %v", err)
+	}
+
+	// 4. Create Module C in Runtime 2, but import the "wrapper" from Runtime 1
+	wasmC, _ := wabt.Wat2Wasm(`(module
+		(import "env" "wrapper" (func $wrapper (result i32)))
+		(func (export "exploit") (result i32) call $wrapper)
+	)`)
+
+	imports := NewModuleImportBuilder("env").
+		AddModuleExports(modA).
+		Build()
+
+	_, err = r2.InstantiateModuleWithImports(bytes.NewReader(wasmC), imports)
+	if err == nil {
+		t.Fatal("expected error when instantiating module with " +
+			"cross-runtime function import")
+	}
+
+	expectedErrMsg := "cross-runtime function import of env.wrapper is forbidden"
+	if err.Error() != expectedErrMsg {
+		t.Fatalf("expected error %q, got %q", expectedErrMsg, err.Error())
+	}
+}


### PR DESCRIPTION
_Written by Gemini and Claude_

### VULN-04 · Cross-Runtime Isolation Bypass (Runtime Confusion)

| Field | Value |
|-------|-------|
| **Severity** | Critical |
| **Component** | `epsilon/vm.go` — store index resolution |
| **Impact** | Cross-runtime resource access, complete sandbox breach, DoS |

#### Description

`ModuleInstance` objects store indices into the VM's internal `store`. These indices are resolved at instantiation time and are specific to that `Runtime`. However, nothing prevents a `ModuleInstance` (or its exported functions) from being shared across different `Runtime` instances.

When a function from Runtime A executes within Runtime B's VM, it uses its original store indices — which now point to *different* resources in Runtime B.

#### Example (WAT)

```wasm
;; Module A in Runtime 1 — $secret returns 42, at store index 0
(module
  (func $secret (result i32) i32.const 42)
  (func (export "wrapper") (result i32) call $secret)
)

;; Module B in Runtime 2 — $secret returns 1337, also at store index 0
(module
  (func $secret (result i32) i32.const 1337)
  (export "unused" (func $secret))
)

;; Module C imported into Runtime 2 — calls wrapper from Module A
(module
  (import "env" "wrapper" (func $wrapper (result i32)))
  (func (export "exploit") (result i32) call $wrapper)
)
```

Calling `exploit` returns `1337` (Runtime B's function) instead of `42` (Runtime A's function).

#### Remediation

Bind each `ModuleInstance` to its originating `Runtime`/`vm`. At function call boundaries, verify that the callee's `vm` matches the current execution context, or copy store references properly.