### PR TITLE
Add bounds checking for block type indices

### DIFF
--- a/epsilon/validation.go
+++ b/epsilon/validation.go
@@ -39,6 +39,7 @@ var (
 	errInvalidRefNullType          = errors.New("invalid ref.null type")
 	errInvalidStartFunction        = errors.New("invalid start function")
 	errInvalidTableType            = errors.New("invalid table type")
+	errInvalidBlockType            = errors.New("invalid block type")
 	errLocalIndexOutOfBounds       = errors.New("local index out of bounds")
 	errMemoryIndexOutOfBounds      = errors.New("memory index out of bounds")
 	errMultipleMemoriesNotEnabled  = errors.New("multiple memories not enabled")
@@ -670,7 +671,10 @@ func (v *validator) validate(op opcode) error {
 }
 
 func (v *validator) validateBlock(op opcode) error {
-	startTypes, endTypes := v.getBlockTypes(int32(v.next()))
+	startTypes, endTypes, err := v.getBlockTypes(int32(v.next()))
+	if err != nil {
+		return err
+	}
 	if _, err := v.popExpectedValues(startTypes); err != nil {
 		return err
 	}
@@ -1474,17 +1478,24 @@ func (v *validator) markFrameUnreachable() error {
 	return nil
 }
 
-func (v *validator) getBlockTypes(blockType int32) ([]ValueType, []ValueType) {
+func (v *validator) getBlockTypes(blockType int32) ([]ValueType, []ValueType, error) {
 	if blockType == -0x40 { // empty block type.
-		return []ValueType{}, []ValueType{}
+		return []ValueType{}, []ValueType{}, nil
 	}
 
 	if blockType >= 0 {
+		if blockType >= int32(len(v.typeDefs)) {
+			return nil, nil, errInvalidBlockType
+		}
 		funcType := v.typeDefs[blockType]
-		return funcType.ParamTypes, funcType.ResultTypes
+		return funcType.ParamTypes, funcType.ResultTypes, nil
 	}
 
-	return []ValueType{}, []ValueType{toValueType(uint64(blockType & 0x7F))}
+	vt := toValueType(uint64(blockType & 0x7F))
+	if vt == bottom {
+		return nil, nil, errInvalidBlockType
+	}
+	return []ValueType{}, []ValueType{vt}, nil
 }
 
 func toValueType(code uint64) ValueType {

--- a/epsilon/validation_test.go
+++ b/epsilon/validation_test.go
@@ -79,15 +79,15 @@ func TestValidDataMemory(t *testing.T) {
 }
 
 func TestVuln06(t *testing.T) {
-	// Raw WASM bytes from VULN-06 report.
-	// This module has 1 type definition (index 0) but tries to use index 1 in a block.
+	// We use raw bytes because standard assemblers like wat2wasm often 
+	// catch or "fix" OOB indices before they reach the engine.
 	wasm := []byte{
 		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
 		0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // 1 type definition
-		0x03, 0x02, 0x01, 0x00,
-		0x0a, 0x08, 0x01, 0x06, 0x00,
-		0x02, 0x01, // block (type index 1) — OOB
-		0x0b, 0x0b,
+		0x03, 0x02, 0x01, 0x00,             // 1 function, type index 0
+		0x0a, 0x07, 0x01, 0x05, 0x00,       // code size 7, function body size 5
+		0x02, 0x01,                         // block, type index 1 (OOB)
+		0x0b, 0x0b,                         // end of block, end of function
 	}
 
 	module, err := newParser(bytes.NewReader(wasm)).parse()
@@ -96,14 +96,8 @@ func TestVuln06(t *testing.T) {
 	}
 	validator := newValidator(Config{})
 
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Recovered from panic: %v", r)
-		}
-	}()
-
 	err = validator.validateModule(module)
 	if err == nil {
-		t.Errorf("expected validation error, got nil")
+		t.Errorf("expected validation error for OOB block type index, got nil")
 	}
 }

--- a/epsilon/validation_test.go
+++ b/epsilon/validation_test.go
@@ -79,15 +79,15 @@ func TestValidDataMemory(t *testing.T) {
 }
 
 func TestVuln06(t *testing.T) {
-	// We use raw bytes because standard assemblers like wat2wasm often 
+	// We use raw bytes because standard assemblers like wat2wasm often
 	// catch or "fix" OOB indices before they reach the engine.
 	wasm := []byte{
 		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
 		0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // 1 type definition
-		0x03, 0x02, 0x01, 0x00,             // 1 function, type index 0
-		0x0a, 0x07, 0x01, 0x05, 0x00,       // code size 7, function body size 5
-		0x02, 0x01,                         // block, type index 1 (OOB)
-		0x0b, 0x0b,                         // end of block, end of function
+		0x03, 0x02, 0x01, 0x00, // 1 function, type index 0
+		0x0a, 0x07, 0x01, 0x05, 0x00, // code size 7, function body size 5
+		0x02, 0x01, // block, type index 1 (OOB)
+		0x0b, 0x0b, // end of block, end of function
 	}
 
 	module, err := newParser(bytes.NewReader(wasm)).parse()

--- a/epsilon/validation_test.go
+++ b/epsilon/validation_test.go
@@ -77,3 +77,33 @@ func TestValidDataMemory(t *testing.T) {
 		t.Fatalf("expected validation success, got error: %v", err)
 	}
 }
+
+func TestVuln06(t *testing.T) {
+	// Raw WASM bytes from VULN-06 report.
+	// This module has 1 type definition (index 0) but tries to use index 1 in a block.
+	wasm := []byte{
+		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+		0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // 1 type definition
+		0x03, 0x02, 0x01, 0x00,
+		0x0a, 0x08, 0x01, 0x06, 0x00,
+		0x02, 0x01, // block (type index 1) — OOB
+		0x0b, 0x0b,
+	}
+
+	module, err := newParser(bytes.NewReader(wasm)).parse()
+	if err != nil {
+		t.Fatalf("failed to parse module: %v", err)
+	}
+	validator := newValidator(Config{})
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Recovered from panic: %v", r)
+		}
+	}()
+
+	err = validator.validateModule(module)
+	if err == nil {
+		t.Errorf("expected validation error, got nil")
+	}
+}


### PR DESCRIPTION
_Written by Gemini and Claude_

### VULN-06 · Validator Panic on Out-of-Bounds Block Type Index

| Field | Value |
|-------|-------|
| **Severity** | High |
| **Component** | `epsilon/validation.go` — `getBlockTypes` |
| **Impact** | Engine panic during instantiation (DoS) |

#### Description

When validating `block`, `loop`, or `if` instructions, the validator reads a `blocktype` immediate. If positive, it indexes into `v.typeDefs` without bounds checking.

#### Root Cause

```go
func (v *validator) getBlockTypes(blockType int32) ([]ValueType, []ValueType) {
    if blockType >= 0 {
        funcType := v.typeDefs[blockType] // PANIC if blockType >= len(v.typeDefs)
        return funcType.ParamTypes, funcType.ResultTypes
    }
}
```

#### Remediation

Add a bounds check: `if blockType >= int32(len(v.typeDefs)) { return error }`.
