### PR TITLE
Fix integer division remainder panic in rem_s instructions

### DIFF
--- a/epsilon/numeric.go
+++ b/epsilon/numeric.go
@@ -152,12 +152,18 @@ func remS32(a, b int32) (int32, error) {
 	if b == 0 {
 		return 0, errIntegerDivideByZero
 	}
+	if a == math.MinInt32 && b == -1 {
+		return 0, nil
+	}
 	return a % b, nil
 }
 
 func remS64(a, b int64) (int64, error) {
 	if b == 0 {
 		return 0, errIntegerDivideByZero
+	}
+	if a == math.MinInt64 && b == -1 {
+		return 0, nil
 	}
 	return a % b, nil
 }

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -1131,3 +1131,40 @@ func TestBlockParamUnwind(t *testing.T) {
 		t.Errorf("expected 10, got %d", observedValue)
 	}
 }
+
+func TestRemSPanic(t *testing.T) {
+	wat := `(module
+		(func (export "rem32") (result i32)
+			i32.const -2147483648
+			i32.const -1
+			i32.rem_s)
+		(func (export "rem64") (result i64)
+			i64.const -9223372036854775808
+			i64.const -1
+			i64.rem_s)
+	)`
+	moduleInstance, err := instantiate(wat, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create vm: %v", err)
+	}
+
+	t.Run("i32.rem_s MinInt32 -1", func(t *testing.T) {
+		result, err := moduleInstance.Invoke("rem32")
+		if err != nil {
+			t.Fatalf("failed to execute rem32: %v", err)
+		}
+		if result[0] != int32(0) {
+			t.Errorf("expected 0, got %v", result[0])
+		}
+	})
+
+	t.Run("i64.rem_s MinInt64 -1", func(t *testing.T) {
+		result, err := moduleInstance.Invoke("rem64")
+		if err != nil {
+			t.Fatalf("failed to execute rem64: %v", err)
+		}
+		if result[0] != int64(0) {
+			t.Errorf("expected 0, got %v", result[0])
+		}
+	})
+}


### PR DESCRIPTION
_Written by Gemini and Claude_

### Integer Division Remainder Panic (i32.rem_s)
| Field | Value |
|-------|-------|
| **Severity** | High |
| **Component** | `epsilon/vm.go` — arithmetic instructions |
| **Impact** | Engine panic (DoS) |

#### Description

Computing `i32.rem_s(MinInt32, -1)` causes a hardware-level panic in Go on some architectures (like x86). The WebAssembly specification mandates that this operation returns `0`, but Epsilon did not handle this edge case.

#### Example (WAT)

```wasm
(module
  (func (export "rem") (result i32)
    i32.const -2147483648  ;; MinInt32
    i32.const -1
    i32.rem_s              ;; should return 0, but panics
  )
)
```

#### Remediation

Before executing `rem_s`, check for divisor `== -1` with dividend `== MinInt` and return `0` directly. This PR applies the fix to both `i32.rem_s` and `i64.rem_s`.
