### PR TITLE
Further reference type args validation

### DIFF
--- a/epsilon/instance.go
+++ b/epsilon/instance.go
@@ -21,6 +21,8 @@ import (
 )
 
 var errExportNotFound = errors.New("export not found")
+var errRefTypeMismatch = errors.New("ref type expected to be int32")
+var errArgCountMismatch = errors.New("arg count mismatch")
 
 // exportInstance represents the runtime representation of an export.
 type exportInstance struct {
@@ -45,6 +47,7 @@ type ModuleInstance struct {
 //
 // Args can be int32, int64, float32, or float64. The function returns a slice
 // of results as []any, which can be type-asserted to the appropriate types.
+// References must be represented as int32, with NullReference for nulls.
 func (m *ModuleInstance) Invoke(name string, args ...any) ([]any, error) {
 	function, err := m.GetFunction(name)
 	if err != nil {
@@ -60,14 +63,28 @@ func (m *ModuleInstance) validateRefArgs(
 	funcType *FunctionType,
 	args []any,
 ) error {
+	if len(args) != len(funcType.ParamTypes) {
+		return errArgCountMismatch
+	}
+
 	for i, paramType := range funcType.ParamTypes {
-		if paramType != FuncRefType {
+		if paramType != FuncRefType && paramType != ExternRefType {
 			continue
 		}
 		idx, ok := args[i].(int32)
-		if !ok || idx == NullReference {
+		if !ok {
+			return errRefTypeMismatch
+		}
+
+		if idx == NullReference {
 			continue
 		}
+
+		if paramType == ExternRefType {
+			// It is up to the host to validate the externref.
+			continue
+		}
+
 		// BinarySearch is safe here because funcAddrs is strictly increasing by
 		// construction as functions are sequentially appended during instantiation.
 		if _, found := slices.BinarySearch(m.funcAddrs, uint32(idx)); !found {


### PR DESCRIPTION
This is a follow-up to #49, which introduced the original ref type validation.

Specifically, this update:
- **Closes a reference type validation bypass**: Previously, if an argument for a `FuncRefType` was passed as a non-`int32` Go type (e.g., an `int64`), the type assertion would fail and the authorization check against `m.funcAddrs` would be silently skipped. The unvalidated value would then be pushed to the stack, allowing a caller to bypass isolation and access unauthorized functions in the global store. This PR explicitly rejects invalid types with an error.
- **Enforces argument counts**: Adds a strict check to ensure the number of arguments provided by the host matches the number of parameters expected by the WebAssembly function, preventing index out-of-bounds panics if fewer arguments are provided.
- **Clarifies `externref` handling**: Adds explicit logic to handle `ExternRefType`. It guarantees the value is a properly formatted `int32` handle, but correctly skips the internal `BinarySearch` validation, clarifying that semantic validation of opaque host references is the responsibility of the host integration.
