### PR TITLE
Fix Uninitialized Reference Local Leak

### DIFF
--- a/epsilon/module.go
+++ b/epsilon/module.go
@@ -25,6 +25,9 @@ type function struct {
 	// the position of the instruction after the matching 'else' (or 'end' if no
 	// else).
 	jumpElseCache map[uint32]uint32
+	// defaultLocals contains the initial values of all non-parameter locals.
+	// It is nil if the function does not contain any reference type locals.
+	defaultLocals []value
 }
 
 type exportIndexKind int

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -313,11 +313,29 @@ func (p *parser) parseFunction() (function, error) {
 
 	body := result.bytecode
 
+	var defaultLocals []value
+	var hasRef bool
+	for _, typ := range locals {
+		if typ == FuncRefType || typ == ExternRefType {
+			hasRef = true
+			break
+		}
+	}
+	if hasRef {
+		defaultLocals = make([]value, len(locals))
+		for i, typ := range locals {
+			if typ == FuncRefType || typ == ExternRefType {
+				defaultLocals[i] = i32(NullReference)
+			}
+		}
+	}
+
 	return function{
 		locals:        locals,
 		body:          body,
 		jumpCache:     result.jumpCache,
 		jumpElseCache: result.jumpElseCache,
+		defaultLocals: defaultLocals,
 	}, nil
 }
 

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -249,10 +249,17 @@ func (vm *vm) invokeWasmFunction(function *wasmFunction) error {
 		// Clear non-parameter locals to their zero values. WASM allows reading
 		// uninitialized locals, so we must zero them to avoid reusing stale values
 		// from previous invocations. Parameters are overwritten below.
-		clear(locals[numParams:])
+		if function.code.defaultLocals != nil {
+			copy(locals[numParams:], function.code.defaultLocals)
+		} else {
+			clear(locals[numParams:])
+		}
 	} else {
 		// Beyond preallocation or too many locals: heap allocate.
 		locals = make([]value, numLocals)
+		if function.code.defaultLocals != nil {
+			copy(locals[numParams:], function.code.defaultLocals)
+		}
 	}
 
 	// Copy params and shrink stack by operating on the underlying slice directly.

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -1161,3 +1161,62 @@ func TestBlockParamUnwind(t *testing.T) {
 		t.Errorf("expected 10, got %d", observedValue)
 	}
 }
+
+func TestUninitializedFuncrefLeak(t *testing.T) {
+	// Module A has a secret function that it DOES NOT export.
+	// We want this function to be at store index 0.
+	watA := `(module
+	  (func (result i32)
+	    i32.const 42
+	  )
+	)`
+
+	// Module B has a function that uses an uninitialized funcref local.
+	// It puts it into a table and then calls it via call_indirect.
+	// If the local is improperly initialized to 0, it will call Module A's secret function.
+	watB := `(module
+	  (type $t0 (func (result i32)))
+	  (table 1 funcref)
+	  (func (export "exploit") (result i32)
+	    (local $ref funcref)
+	    i32.const 0
+	    local.get $ref
+	    table.set 0
+	    i32.const 0
+	    call_indirect (type $t0)
+	  )
+	)`
+
+	runtime := NewRuntime()
+
+	wasmA, err := wabt.Wat2Wasm(watA)
+	if err != nil {
+		t.Fatalf("wat2wasm A failed: %v", err)
+	}
+
+	wasmB, err := wabt.Wat2Wasm(watB)
+	if err != nil {
+		t.Fatalf("wat2wasm B failed: %v", err)
+	}
+
+	// Instantiate Module A first so its function gets index 0.
+	_, err = runtime.InstantiateModule(bytes.NewReader(wasmA))
+	if err != nil {
+		t.Fatalf("failed to instantiate Module A: %v", err)
+	}
+
+	// Instantiate Module B.
+	instanceB, err := runtime.InstantiateModule(bytes.NewReader(wasmB))
+	if err != nil {
+		t.Fatalf("failed to instantiate Module B: %v", err)
+	}
+
+	// Invoke "exploit" from Module B.
+	// If the vulnerability exists, it will return 42 (Module A's secret).
+	results, err := instanceB.Invoke("exploit")
+	if err != nil {
+		t.Logf("Invoke failed (this is good if it was a trap): %v", err)
+	} else if len(results) > 0 && results[0] == int32(42) {
+		t.Errorf("Vulnerability confirmed! Module B successfully called Module A's private function.")
+	}
+}

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -1214,9 +1214,15 @@ func TestUninitializedFuncrefLeak(t *testing.T) {
 	// Invoke "exploit" from Module B.
 	// If the vulnerability exists, it will return 42 (Module A's secret).
 	results, err := instanceB.Invoke("exploit")
-	if err != nil {
-		t.Logf("Invoke failed (this is good if it was a trap): %v", err)
-	} else if len(results) > 0 && results[0] == int32(42) {
-		t.Errorf("Vulnerability confirmed! Module B successfully called Module A's private function.")
+	if err == nil {
+		if len(results) > 0 && results[0] == int32(42) {
+			t.Fatalf("Vulnerability confirmed! Module B successfully called Module A's private function.")
+		}
+		t.Fatalf("Expected a trap due to uninitialized funcref, but execution succeeded.")
+	}
+
+	expectedErr := "uninitialized element 0"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected trap '%s', got '%v'", expectedErr, err)
 	}
 }

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -1173,7 +1173,8 @@ func TestUninitializedFuncrefLeak(t *testing.T) {
 
 	// Module B has a function that uses an uninitialized funcref local.
 	// It puts it into a table and then calls it via call_indirect.
-	// If the local is improperly initialized to 0, it will call Module A's secret function.
+	// If the local is improperly initialized to 0, it will call Module A's secret
+	// function.
 	watB := `(module
 	  (type $t0 (func (result i32)))
 	  (table 1 funcref)

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -1216,13 +1216,8 @@ func TestUninitializedFuncrefLeak(t *testing.T) {
 	results, err := instanceB.Invoke("exploit")
 	if err == nil {
 		if len(results) > 0 && results[0] == int32(42) {
-			t.Fatalf("Vulnerability confirmed! Module B successfully called Module A's private function.")
+			t.Fatalf("module B successfully called module A's private function")
 		}
-		t.Fatalf("Expected a trap due to uninitialized funcref, but execution succeeded.")
-	}
-
-	expectedErr := "uninitialized element 0"
-	if err.Error() != expectedErr {
-		t.Errorf("Expected trap '%s', got '%v'", expectedErr, err)
+		t.Fatalf("expected trap due to uninitialized funcref")
 	}
 }


### PR DESCRIPTION
# The Tale of the Uninitialized Reference Leak

WebAssembly provides robust sandbox guarantees, ensuring that one module cannot arbitrarily peer into the memory or state of another. However, an insidious implementation bug in how the Epsilon VM initialized its function locals inadvertently broke these guarantees, creating a cross-module isolation leak.

## How Locals Work in WebAssembly

When a WebAssembly function executes, it can declare "local" variables. These variables are always zero-initialized by default. For numeric types (`i32`, `i64`, `f32`, `f64`), initializing to `0` is correct. However, for reference types (`funcref` and `externref`), `0` is a highly problematic default.

In the Epsilon engine's internal implementation, reference types are represented as indices into a central storage area (the "store"). A value of `0` means "the reference stored at index `0`." To represent a null reference, the VM actually relies on `-1` (or `NullReference`). 

When allocating a new frame, the VM simply executed `clear(locals)`, wiping the memory clean. While fast, this effectively assigned the reference value `0` to every uninitialized `funcref` instead of `-1`.

## Exploiting the Default State

To exploit this, an attacker only needed to declare a local `funcref` and immediately use it before setting it to anything. Because its default internal value was incorrectly set to `0`, the `funcref` secretly pointed to whatever function happened to reside at index `0` of the global store.

Here is what the exploit looks like in WebAssembly Text format (WAT):

```wat
(module
  (type $t0 (func (result i32)))
  (table 1 funcref)
  (func (export "exploit") (result i32)
    ;; 1. Declare a funcref local. 
    ;; Due to the bug, it is incorrectly initialized to store index 0 instead of null!
    (local $ref funcref)
    
    i32.const 0
    
    ;; 2. Push the uninitialized local onto the stack.
    local.get $ref
    
    ;; 3. Store the leaked reference into the module's table at index 0.
    table.set 0
    
    i32.const 0
    
    ;; 4. Call the leaked reference. If the function at store index 0 is 
    ;; a secret function from another module, we just successfully bypassed 
    ;; isolation and called it!
    call_indirect (type $t0)
  )
)
```

By ensuring a victim module is instantiated first, its secret/internal functions would be placed at the beginning of the store (index 0). A malicious module could then instantiate, read its uninitialized `funcref`, and seamlessly execute the victim's private code!

## The Fix

To remediate this, we've shifted the initialization logic to the parsing phase. The engine now pre-computes an array of `defaultLocals` for every function containing reference types (properly initialized to `-1`). During execution, if a function requires default references, the VM gracefully copies this pre-computed array over the allocated locals. Otherwise, it falls back to the blistering fast `clear()` operation. This comprehensively closes the leak while maintaining optimal execution speed.
