### PR TITLE
Cross Runtime isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,15 @@ func main() {
 ### Using Host Functions
 
 Extend your WebAssembly modules with custom Go functions and more using 
-`ModuleImportBuilder`:
+`ModuleImports`:
 
 ```go
 // Create imports before instantiation
-imports := epsilon.NewModuleImportBuilder("env").
+imports := epsilon.NewModuleImports("env").
 	AddHostFunc("log", func(m *epsilon.ModuleInstance, args ...any) []any {
 		fmt.Printf("[WASM Log]: %v\n", args[0])
 		return nil
-	}).
-	Build()
+	})
 
 // Instantiate with imports
 instance, _ := epsilon.NewRuntime().

--- a/cmd/epsilon/main.go
+++ b/cmd/epsilon/main.go
@@ -144,8 +144,7 @@ func run(opts *options) error {
 		config.Fuel = opts.fuel
 	}
 
-	instance, err := epsilon.NewRuntime().
-		WithConfig(config).
+	instance, err := epsilon.NewRuntimeWithConfig(config).
 		InstantiateModuleWithImports(moduleReader, wasiModule.ToImports())
 	if err != nil {
 		return err

--- a/epsilon/global.go
+++ b/epsilon/global.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package epsilon
+
+// Global is a global variable.
+type Global struct {
+	value   value
+	Mutable bool
+	Type    ValueType
+
+	// owner identifies which vm and therefore which runtime this instance
+	// belongs to.
+	owner *vm
+}
+
+func newGlobal(
+	owner *vm,
+	v any,
+	mutable bool,
+	valueType ValueType,
+) *Global {
+	var val value
+	if gv, ok := v.(value); ok {
+		val = gv
+	} else {
+		val = newValue(v)
+	}
+	return &Global{
+		owner:   owner,
+		value:   val,
+		Mutable: mutable,
+		Type:    valueType,
+	}
+}
+
+func (g *Global) Get() any {
+	return g.value.any(g.Type)
+}

--- a/epsilon/imports.go
+++ b/epsilon/imports.go
@@ -50,19 +50,19 @@ func resolveImports(
 			}
 			functions = append(functions, function)
 		case GlobalType:
-			global, err := resolveGlobalImport(obj, t, imp)
+			global, err := resolveGlobalImport(instance, obj, t, imp)
 			if err != nil {
 				return nil, err
 			}
 			globals = append(globals, global)
 		case MemoryType:
-			memory, err := resolveMemoryImport(obj, t, imp)
+			memory, err := resolveMemoryImport(instance, obj, t, imp)
 			if err != nil {
 				return nil, err
 			}
 			memories = append(memories, memory)
 		case TableType:
-			table, err := resolveTableImport(obj, t, imp)
+			table, err := resolveTableImport(instance, obj, t, imp)
 			if err != nil {
 				return nil, err
 			}
@@ -96,6 +96,20 @@ func resolveFunctionImport(
 	imp moduleImport,
 ) (FunctionInstance, error) {
 	if f, ok := obj.(FunctionInstance); ok {
+		var owner *vm
+		switch t := f.(type) {
+		case *wasmFunction:
+			owner = t.module.vm
+		case *hostFunction:
+			owner = t.module.vm
+		}
+
+		if owner != moduleInstance.vm {
+			return nil, fmt.Errorf(
+				"cross-runtime import of %s.%s is forbidden", imp.moduleName, imp.name,
+			)
+		}
+
 		if !f.GetType().Equal(functionType) {
 			return nil, fmt.Errorf(
 				"type mismatch for %s.%s", imp.moduleName, imp.name,
@@ -117,6 +131,7 @@ func resolveFunctionImport(
 }
 
 func resolveGlobalImport(
+	instance *ModuleInstance,
 	obj any,
 	globalType GlobalType,
 	imp moduleImport,
@@ -124,6 +139,12 @@ func resolveGlobalImport(
 	global, ok := obj.(*Global)
 	if !ok {
 		return nil, fmt.Errorf("%s.%s not a global", imp.moduleName, imp.name)
+	}
+
+	if global.owner != instance.vm {
+		return nil, fmt.Errorf(
+			"cross-runtime import of %s.%s is forbidden", imp.moduleName, imp.name,
+		)
 	}
 
 	if global.Mutable != globalType.IsMutable {
@@ -140,6 +161,7 @@ func resolveGlobalImport(
 }
 
 func resolveMemoryImport(
+	instance *ModuleInstance,
 	obj any,
 	memoryType MemoryType,
 	imp moduleImport,
@@ -147,6 +169,12 @@ func resolveMemoryImport(
 	memory, ok := obj.(*Memory)
 	if !ok {
 		return nil, fmt.Errorf("%s.%s not a memory", imp.moduleName, imp.name)
+	}
+
+	if memory.owner != instance.vm {
+		return nil, fmt.Errorf(
+			"cross-runtime import of %s.%s is forbidden", imp.moduleName, imp.name,
+		)
 	}
 
 	provided := Limits{Min: uint32(memory.Size()), Max: memory.Limits.Max}
@@ -157,6 +185,7 @@ func resolveMemoryImport(
 }
 
 func resolveTableImport(
+	instance *ModuleInstance,
 	obj any,
 	tableType TableType,
 	imp moduleImport,
@@ -164,6 +193,12 @@ func resolveTableImport(
 	table, ok := obj.(*Table)
 	if !ok {
 		return nil, fmt.Errorf("%s.%s not a table", imp.moduleName, imp.name)
+	}
+
+	if table.owner != instance.vm {
+		return nil, fmt.Errorf(
+			"cross-runtime import of %s.%s is forbidden", imp.moduleName, imp.name,
+		)
 	}
 
 	if table.Type.ReferenceType != tableType.ReferenceType {

--- a/epsilon/imports.go
+++ b/epsilon/imports.go
@@ -102,18 +102,6 @@ func resolveFunctionImport(
 			)
 		}
 
-		// Prevent cross-runtime function sharing. The WebAssembly spec assumes a
-		// single Store per abstract machine. Mixing objects across Runtimes breaks
-		// isolation and is forbidden.
-		if wasmFn, isWasm := f.(*wasmFunction); isWasm {
-			if wasmFn.module.vm != moduleInstance.vm {
-				return nil, fmt.Errorf(
-					"cross-runtime function import of %s.%s is forbidden",
-					imp.moduleName, imp.name,
-				)
-			}
-		}
-
 		return f, nil
 	}
 

--- a/epsilon/imports.go
+++ b/epsilon/imports.go
@@ -96,15 +96,7 @@ func resolveFunctionImport(
 	imp moduleImport,
 ) (FunctionInstance, error) {
 	if f, ok := obj.(FunctionInstance); ok {
-		var owner *vm
-		switch t := f.(type) {
-		case *wasmFunction:
-			owner = t.module.vm
-		case *hostFunction:
-			owner = t.module.vm
-		}
-
-		if owner != moduleInstance.vm {
+		if f.owner() != moduleInstance.vm {
 			return nil, fmt.Errorf(
 				"cross-runtime import of %s.%s is forbidden", imp.moduleName, imp.name,
 			)

--- a/epsilon/imports.go
+++ b/epsilon/imports.go
@@ -133,30 +133,22 @@ func resolveGlobalImport(
 	globalType GlobalType,
 	imp moduleImport,
 ) (*Global, error) {
-	if global, ok := obj.(*Global); ok {
-		if global.Mutable != globalType.IsMutable {
-			return nil, fmt.Errorf(
-				"mutability mismatch for %s.%s", imp.moduleName, imp.name,
-			)
-		}
-		if global.Type != nil && global.Type != globalType.ValueType {
-			return nil, fmt.Errorf(
-				"value type mismatch for %s.%s", imp.moduleName, imp.name,
-			)
-		}
-		return global, nil
+	global, ok := obj.(*Global)
+	if !ok {
+		return nil, fmt.Errorf("%s.%s not a global", imp.moduleName, imp.name)
 	}
 
-	if !valueMatchesType(obj, globalType.ValueType) {
+	if global.Mutable != globalType.IsMutable {
+		return nil, fmt.Errorf(
+			"mutability mismatch for %s.%s", imp.moduleName, imp.name,
+		)
+	}
+	if global.Type != nil && global.Type != globalType.ValueType {
 		return nil, fmt.Errorf(
 			"value type mismatch for %s.%s", imp.moduleName, imp.name,
 		)
 	}
-	return &Global{
-		value:   newValue(obj),
-		Mutable: globalType.IsMutable,
-		Type:    globalType.ValueType,
-	}, nil
+	return global, nil
 }
 
 func resolveMemoryImport(
@@ -199,28 +191,6 @@ func resolveTableImport(
 		)
 	}
 	return table, nil
-}
-
-func valueMatchesType(val any, valueType ValueType) bool {
-	switch valueType {
-	case I32:
-		_, ok := val.(int32)
-		return ok
-	case I64:
-		_, ok := val.(int64)
-		return ok
-	case F32:
-		_, ok := val.(float32)
-		return ok
-	case F64:
-		_, ok := val.(float64)
-		return ok
-	case V128:
-		_, ok := val.(V128Value)
-		return ok
-	default:
-		return false
-	}
 }
 
 func limitsMatch(provided, required Limits) bool {

--- a/epsilon/instance.go
+++ b/epsilon/instance.go
@@ -185,14 +185,3 @@ type hostFunction struct {
 }
 
 func (hf *hostFunction) GetType() *FunctionType { return &hf.functionType }
-
-// Global is a global variable.
-type Global struct {
-	value   value
-	Mutable bool
-	Type    ValueType
-}
-
-func (g *Global) Get() any {
-	return g.value.any(g.Type)
-}

--- a/epsilon/instance.go
+++ b/epsilon/instance.go
@@ -166,6 +166,7 @@ func (m *ModuleInstance) findExport(name string) (any, error) {
 
 type FunctionInstance interface {
 	GetType() *FunctionType
+	owner() *vm
 }
 
 // wasmFunction is the runtime representation of a function defined in WASM.
@@ -176,6 +177,7 @@ type wasmFunction struct {
 }
 
 func (wf *wasmFunction) GetType() *FunctionType { return &wf.functionType }
+func (wf *wasmFunction) owner() *vm             { return wf.module.vm }
 
 // hostFunction represents a function defined by the host environment.
 type hostFunction struct {
@@ -185,3 +187,4 @@ type hostFunction struct {
 }
 
 func (hf *hostFunction) GetType() *FunctionType { return &hf.functionType }
+func (hf *hostFunction) owner() *vm             { return hf.module.vm }

--- a/epsilon/memory.go
+++ b/epsilon/memory.go
@@ -32,15 +32,17 @@ var errMemoryOutOfBounds = errors.New("out of bounds memory access")
 type Memory struct {
 	Limits Limits
 	data   []byte
+
+	// owner identifies which vm and therefore which runtime this instance
+	// belongs to.
+	owner *vm
 }
 
-// NewMemory creates a new Memory instance from a MemoryType.
-func NewMemory(memType MemoryType) *Memory {
+// newMemory creates a new Memory instance from a MemoryType.
+func newMemory(owner *vm, memType MemoryType) *Memory {
 	size := uint64(memType.Limits.Min) * pageSize
-	return &Memory{
-		Limits: memType.Limits,
-		data:   make([]byte, size),
-	}
+	data := make([]byte, size)
+	return &Memory{owner: owner, Limits: memType.Limits, data: data}
 }
 
 // Grow extends the memory by the given number of pages.

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -37,6 +37,45 @@ func NewRuntimeWithConfig(config Config) *Runtime {
 	return &Runtime{config: config, vm: newVm(config)}
 }
 
+// NewMemory creates a new Memory instance from a MemoryType.
+func (r *Runtime) NewMemory(memType MemoryType) *Memory {
+	return newMemory(r.vm, memType)
+}
+
+// NewTable creates a new Table instance from a TableType.
+func (r *Runtime) NewTable(tt TableType) *Table {
+	return newTable(r.vm, tt)
+}
+
+// NewGlobal creates a new Global instance.
+func (r *Runtime) NewGlobal(
+	value any,
+	mutable bool,
+	valueType ValueType,
+) *Global {
+	return newGlobal(r.vm, value, mutable, valueType)
+}
+
+// NewGlobalI32 creates a new I32 Global instance.
+func (r *Runtime) NewGlobalI32(value int32, mutable bool) *Global {
+	return r.NewGlobal(value, mutable, I32)
+}
+
+// NewGlobalI64 creates a new I64 Global instance.
+func (r *Runtime) NewGlobalI64(value int64, mutable bool) *Global {
+	return r.NewGlobal(value, mutable, I64)
+}
+
+// NewGlobalF32 creates a new F32 Global instance.
+func (r *Runtime) NewGlobalF32(value float32, mutable bool) *Global {
+	return r.NewGlobal(value, mutable, F32)
+}
+
+// NewGlobalF64 creates a new F64 Global instance.
+func (r *Runtime) NewGlobalF64(value float64, mutable bool) *Global {
+	return r.NewGlobal(value, mutable, F64)
+}
+
 // InstantiateModule parses and instantiates a WASM module from an io.Reader.
 func (r *Runtime) InstantiateModule(wasm io.Reader) (*ModuleInstance, error) {
 	return r.InstantiateModuleWithImports(wasm, map[string]map[string]any{})
@@ -79,15 +118,16 @@ func (r *Runtime) InstantiateModuleFromBytes(
 //
 // Example:
 //
+//	runtime := epsilon.NewRuntime()
 //	imports := epsilon.NewModuleImportBuilder("env").
 //	    AddHostFunc("log", func(m *epsilon.ModuleInstance, args ...any) []any {
 //	        fmt.Println("WASM says:", args[0])
 //	        return nil
 //	    }).
-//	    AddMemory("memory", epsilon.NewMemory(epsilon.MemoryType{
+//	    AddMemory("memory", runtime.NewMemory(epsilon.MemoryType{
 //	        Limits: epsilon.Limits{Min: 1},
 //	    })).
-//	    AddGlobal("offset", int32(1024), false, epsilon.I32).
+//	    AddGlobal("offset", runtime.NewGlobal(int32(1024), false, epsilon.I32)).
 //	    Build()
 //
 //	instance, err := runtime.InstantiateModuleWithImports(wasmReader, imports)
@@ -129,15 +169,9 @@ func (b *ModuleImportBuilder) AddTable(
 
 func (b *ModuleImportBuilder) AddGlobal(
 	name string,
-	value any,
-	mutable bool,
-	valueType ValueType,
+	global *Global,
 ) *ModuleImportBuilder {
-	b.imports[name] = &Global{
-		value:   newValue(value),
-		Mutable: mutable,
-		Type:    valueType,
-	}
+	b.imports[name] = global
 	return b
 }
 

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -27,16 +27,14 @@ type Runtime struct {
 	config Config
 }
 
-// NewRuntime creates a new Runtime with default settings.
+// NewRuntime creates a new Runtime with default configuration.
 func NewRuntime() *Runtime {
-	return &Runtime{config: DefaultConfig()}
+	return NewRuntimeWithConfig(DefaultConfig())
 }
 
-// WithConfig sets the configuration for the runtime. Must be called before
-// instantiating any modules.
-func (r *Runtime) WithConfig(config Config) *Runtime {
-	r.config = config
-	return r
+// NewRuntimeWithConfig creates a new Runtime with the given configuration.
+func NewRuntimeWithConfig(config Config) *Runtime {
+	return &Runtime{config: config, vm: newVm(config)}
 }
 
 // InstantiateModule parses and instantiates a WASM module from an io.Reader.
@@ -50,7 +48,6 @@ func (r *Runtime) InstantiateModuleWithImports(
 	wasm io.Reader,
 	imports ...map[string]map[string]any,
 ) (*ModuleInstance, error) {
-	r.ensureVm()
 	module, err := newParser(wasm).parse()
 	if err != nil {
 		return nil, err
@@ -75,12 +72,6 @@ func (r *Runtime) InstantiateModuleFromBytes(
 	data []byte,
 ) (*ModuleInstance, error) {
 	return r.InstantiateModule(bytes.NewReader(data))
-}
-
-func (r *Runtime) ensureVm() {
-	if r.vm == nil {
-		r.vm = newVm(r.config)
-	}
 }
 
 // ModuleImportBuilder provides a fluent, type-safe API for building import

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -16,8 +16,8 @@ package epsilon
 
 import (
 	"bytes"
+	"fmt"
 	"io"
-	"maps"
 )
 
 // Runtime provides the main API for instantiating and interacting with WASM
@@ -78,14 +78,14 @@ func (r *Runtime) NewGlobalF64(value float64, mutable bool) *Global {
 
 // InstantiateModule parses and instantiates a WASM module from an io.Reader.
 func (r *Runtime) InstantiateModule(wasm io.Reader) (*ModuleInstance, error) {
-	return r.InstantiateModuleWithImports(wasm, map[string]map[string]any{})
+	return r.InstantiateModuleWithImports(wasm)
 }
 
 // InstantiateModuleWithImports parses and instantiates a WASM module with
 // imports.
 func (r *Runtime) InstantiateModuleWithImports(
 	wasm io.Reader,
-	imports ...map[string]map[string]any,
+	imports ...*ModuleImports,
 ) (*ModuleInstance, error) {
 	module, err := newParser(wasm).parse()
 	if err != nil {
@@ -93,12 +93,15 @@ func (r *Runtime) InstantiateModuleWithImports(
 	}
 
 	merged := make(map[string]map[string]any)
-	for _, importMap := range imports {
-		for moduleName, exports := range importMap {
-			if _, exists := merged[moduleName]; !exists {
-				merged[moduleName] = make(map[string]any)
+	for _, mi := range imports {
+		if _, exists := merged[mi.moduleName]; !exists {
+			merged[mi.moduleName] = make(map[string]any)
+		}
+		for name, obj := range mi.imports {
+			if err := r.checkOwner(obj, mi.moduleName, name); err != nil {
+				return nil, err
 			}
-			maps.Copy(merged[moduleName], exports)
+			merged[mi.moduleName][name] = obj
 		}
 	}
 
@@ -113,13 +116,37 @@ func (r *Runtime) InstantiateModuleFromBytes(
 	return r.InstantiateModule(bytes.NewReader(data))
 }
 
-// ModuleImportBuilder provides a fluent, type-safe API for building import
+// checkOwner rejects imports that belong to a different Runtime, as mixing
+// objects across Runtimes breaks isolation.
+func (r *Runtime) checkOwner(obj any, mod, name string) error {
+	var owner *vm
+	switch t := obj.(type) {
+	case *Memory:
+		owner = t.owner
+	case *Table:
+		owner = t.owner
+	case *Global:
+		owner = t.owner
+	case *wasmFunction:
+		owner = t.module.vm
+	default:
+		// Host functions and other unowned types are always safe to import.
+		return nil
+	}
+
+	if owner != r.vm {
+		return fmt.Errorf("cross-runtime import of %s.%s is forbidden", mod, name)
+	}
+	return nil
+}
+
+// ModuleImports provides a fluent, type-safe API for building import
 // objects for a specific WASM module.
 //
 // Example:
 //
 //	runtime := epsilon.NewRuntime()
-//	imports := epsilon.NewModuleImportBuilder("env").
+//	imports := epsilon.NewModuleImports("env").
 //	    AddHostFunc("log", func(m *epsilon.ModuleInstance, args ...any) []any {
 //	        fmt.Println("WASM says:", args[0])
 //	        return nil
@@ -127,50 +154,40 @@ func (r *Runtime) InstantiateModuleFromBytes(
 //	    AddMemory("memory", runtime.NewMemory(epsilon.MemoryType{
 //	        Limits: epsilon.Limits{Min: 1},
 //	    })).
-//	    AddGlobal("offset", runtime.NewGlobal(int32(1024), false, epsilon.I32)).
-//	    Build()
+//	    AddGlobal("offset", runtime.NewGlobal(int32(1024), false, epsilon.I32))
 //
 //	instance, err := runtime.InstantiateModuleWithImports(wasmReader, imports)
-type ModuleImportBuilder struct {
+type ModuleImports struct {
 	moduleName string
 	imports    map[string]any
 }
 
-func NewModuleImportBuilder(moduleName string) *ModuleImportBuilder {
-	return &ModuleImportBuilder{
+func NewModuleImports(moduleName string) *ModuleImports {
+	return &ModuleImports{
 		moduleName: moduleName,
 		imports:    make(map[string]any),
 	}
 }
 
-func (b *ModuleImportBuilder) AddHostFunc(
+func (b *ModuleImports) AddHostFunc(
 	name string,
 	fn func(*ModuleInstance, ...any) []any,
-) *ModuleImportBuilder {
+) *ModuleImports {
 	b.imports[name] = fn
 	return b
 }
 
-func (b *ModuleImportBuilder) AddMemory(
-	name string,
-	memory *Memory,
-) *ModuleImportBuilder {
+func (b *ModuleImports) AddMemory(name string, memory *Memory) *ModuleImports {
 	b.imports[name] = memory
 	return b
 }
 
-func (b *ModuleImportBuilder) AddTable(
-	name string,
-	table *Table,
-) *ModuleImportBuilder {
+func (b *ModuleImports) AddTable(name string, table *Table) *ModuleImports {
 	b.imports[name] = table
 	return b
 }
 
-func (b *ModuleImportBuilder) AddGlobal(
-	name string,
-	global *Global,
-) *ModuleImportBuilder {
+func (b *ModuleImports) AddGlobal(name string, global *Global) *ModuleImports {
 	b.imports[name] = global
 	return b
 }
@@ -178,15 +195,11 @@ func (b *ModuleImportBuilder) AddGlobal(
 // AddModuleExports adds all exports from a ModuleInstance as imports.
 // This is useful when you want to import functions, memories, tables, or
 // globals from one module into another.
-func (b *ModuleImportBuilder) AddModuleExports(
+func (b *ModuleImports) AddModuleExports(
 	instance *ModuleInstance,
-) *ModuleImportBuilder {
+) *ModuleImports {
 	for _, export := range instance.exports {
 		b.imports[export.name] = export.value
 	}
 	return b
-}
-
-func (b *ModuleImportBuilder) Build() map[string]map[string]any {
-	return map[string]map[string]any{b.moduleName: b.imports}
 }

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -16,7 +16,6 @@ package epsilon
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 )
 
@@ -98,9 +97,6 @@ func (r *Runtime) InstantiateModuleWithImports(
 			merged[mi.moduleName] = make(map[string]any)
 		}
 		for name, obj := range mi.imports {
-			if err := r.checkOwner(obj, mi.moduleName, name); err != nil {
-				return nil, err
-			}
 			merged[mi.moduleName][name] = obj
 		}
 	}
@@ -114,30 +110,6 @@ func (r *Runtime) InstantiateModuleFromBytes(
 	data []byte,
 ) (*ModuleInstance, error) {
 	return r.InstantiateModule(bytes.NewReader(data))
-}
-
-// checkOwner rejects imports that belong to a different Runtime, as mixing
-// objects across Runtimes breaks isolation.
-func (r *Runtime) checkOwner(obj any, mod, name string) error {
-	var owner *vm
-	switch t := obj.(type) {
-	case *Memory:
-		owner = t.owner
-	case *Table:
-		owner = t.owner
-	case *Global:
-		owner = t.owner
-	case *wasmFunction:
-		owner = t.module.vm
-	default:
-		// Host functions and other unowned types are always safe to import.
-		return nil
-	}
-
-	if owner != r.vm {
-		return fmt.Errorf("cross-runtime import of %s.%s is forbidden", mod, name)
-	}
-	return nil
 }
 
 // ModuleImports provides a fluent, type-safe API for building import

--- a/epsilon/runtime_test.go
+++ b/epsilon/runtime_test.go
@@ -55,13 +55,12 @@ func TestRuntimeImportedFunction(t *testing.T) {
 			call $multiply)
 	)`)
 
-	imports := NewModuleImportBuilder("env").
+	imports := NewModuleImports("env").
 		AddHostFunc("multiply", func(module *ModuleInstance, args ...any) []any {
 			a := args[0].(int32)
 			b := args[1].(int32)
 			return []any{a * b}
-		}).
-		Build()
+		})
 
 	instance, err := NewRuntime().
 		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
@@ -97,9 +96,7 @@ func TestRuntimeImportedMemory(t *testing.T) {
 		t.Fatalf("failed to set memory: %v", err)
 	}
 
-	imports := NewModuleImportBuilder("env").
-		AddMemory("memory", memory).
-		Build()
+	imports := NewModuleImports("env").AddMemory("memory", memory)
 
 	instance, err := runtime.
 		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
@@ -142,9 +139,8 @@ func TestRuntimeImportedGlobal(t *testing.T) {
 	)`)
 
 	runtime := NewRuntime()
-	imports := NewModuleImportBuilder("env").
-		AddGlobal("offset", runtime.NewGlobal(int32(100), false, I32)).
-		Build()
+	imports := NewModuleImports("env").
+		AddGlobal("offset", runtime.NewGlobal(int32(100), false, I32))
 
 	instance, err := runtime.
 		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
@@ -183,7 +179,7 @@ func TestRuntimeImportedFunctionsInTable(t *testing.T) {
 	)`)
 
 	runtime := NewRuntime()
-	imports := NewModuleImportBuilder("env").
+	imports := NewModuleImports("env").
 		AddHostFunc("host_sub", func(module *ModuleInstance, args ...any) []any {
 			x := args[0].(int32)
 			return []any{x - 1}
@@ -191,8 +187,7 @@ func TestRuntimeImportedFunctionsInTable(t *testing.T) {
 		AddTable("table", runtime.NewTable(TableType{
 			ReferenceType: FuncRefType,
 			Limits:        Limits{Min: 2},
-		})).
-		Build()
+		}))
 
 	instance, err := runtime.
 		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
@@ -247,7 +242,7 @@ func TestRuntimeModuleToModuleImport(t *testing.T) {
 
 	module2, err := runtime.InstantiateModuleWithImports(
 		bytes.NewReader(module2Wasm),
-		NewModuleImportBuilder("math").AddModuleExports(module1).Build(),
+		NewModuleImports("math").AddModuleExports(module1),
 	)
 	if err != nil {
 		t.Fatalf("failed to instantiate module2: %v", err)
@@ -347,9 +342,8 @@ func TestRuntimeConfusion(t *testing.T) {
 		(func (export "exploit") (result i32) call $wrapper)
 	)`)
 
-	imports := NewModuleImportBuilder("env").
-		AddModuleExports(modA).
-		Build()
+	imports := NewModuleImports("env").
+		AddModuleExports(modA)
 
 	_, err = r2.InstantiateModuleWithImports(bytes.NewReader(wasmC), imports)
 	if err == nil {
@@ -357,8 +351,68 @@ func TestRuntimeConfusion(t *testing.T) {
 			"cross-runtime function import")
 	}
 
-	expectedErrMsg := "cross-runtime function import of env.wrapper is forbidden"
+	expectedErrMsg := "cross-runtime import of env.wrapper is forbidden"
 	if err.Error() != expectedErrMsg {
 		t.Fatalf("expected error %q, got %q", expectedErrMsg, err.Error())
+	}
+}
+
+func TestCrossRuntimeMemorySharingIsForbidden(t *testing.T) {
+	r1 := NewRuntime()
+	r2 := NewRuntime()
+
+	mem := r1.NewMemory(MemoryType{Limits: Limits{Min: 1}})
+
+	wasm, _ := wabt.Wat2Wasm(`(module
+		(import "env" "memory" (memory 1))
+	)`)
+
+	imports := NewModuleImports("env").
+		AddMemory("memory", mem)
+
+	_, err := r2.InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
+	if err == nil {
+		t.Fatal("expected error when sharing memory across runtimes")
+	}
+}
+
+func TestCrossRuntimeTableSharingIsForbidden(t *testing.T) {
+	r1 := NewRuntime()
+	r2 := NewRuntime()
+
+	table := r1.NewTable(TableType{
+		ReferenceType: FuncRefType,
+		Limits:        Limits{Min: 1},
+	})
+
+	wasm, _ := wabt.Wat2Wasm(`(module
+		(import "env" "table" (table 1 funcref))
+	)`)
+
+	imports := NewModuleImports("env").
+		AddTable("table", table)
+
+	_, err := r2.InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
+	if err == nil {
+		t.Fatal("expected error when sharing table across runtimes")
+	}
+}
+
+func TestCrossRuntimeGlobalSharingIsForbidden(t *testing.T) {
+	r1 := NewRuntime()
+	r2 := NewRuntime()
+
+	global := r1.NewGlobalI32(42, false)
+
+	wasm, _ := wabt.Wat2Wasm(`(module
+		(import "env" "global" (global i32))
+	)`)
+
+	imports := NewModuleImports("env").
+		AddGlobal("global", global)
+
+	_, err := r2.InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
+	if err == nil {
+		t.Fatal("expected error when sharing global across runtimes")
 	}
 }

--- a/epsilon/runtime_test.go
+++ b/epsilon/runtime_test.go
@@ -89,7 +89,8 @@ func TestRuntimeImportedMemory(t *testing.T) {
 			i32.load)
 	)`)
 
-	memory := NewMemory(MemoryType{Limits: Limits{Min: 1}})
+	runtime := NewRuntime()
+	memory := runtime.NewMemory(MemoryType{Limits: Limits{Min: 1}})
 	testData := binary.LittleEndian.AppendUint32(nil, 42)
 	err := memory.Set(0, 100, testData)
 	if err != nil {
@@ -100,7 +101,7 @@ func TestRuntimeImportedMemory(t *testing.T) {
 		AddMemory("memory", memory).
 		Build()
 
-	instance, err := NewRuntime().
+	instance, err := runtime.
 		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
 	if err != nil {
 		t.Fatalf("failed to instantiate module: %v", err)
@@ -140,11 +141,12 @@ func TestRuntimeImportedGlobal(t *testing.T) {
 			i32.add)
 	)`)
 
+	runtime := NewRuntime()
 	imports := NewModuleImportBuilder("env").
-		AddGlobal("offset", int32(100), false, I32).
+		AddGlobal("offset", runtime.NewGlobal(int32(100), false, I32)).
 		Build()
 
-	instance, err := NewRuntime().
+	instance, err := runtime.
 		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
 	if err != nil {
 		t.Fatalf("failed to instantiate module: %v", err)
@@ -180,18 +182,19 @@ func TestRuntimeImportedFunctionsInTable(t *testing.T) {
 			call_indirect (type $op))
 	)`)
 
+	runtime := NewRuntime()
 	imports := NewModuleImportBuilder("env").
 		AddHostFunc("host_sub", func(module *ModuleInstance, args ...any) []any {
 			x := args[0].(int32)
 			return []any{x - 1}
 		}).
-		AddTable("table", NewTable(TableType{
+		AddTable("table", runtime.NewTable(TableType{
 			ReferenceType: FuncRefType,
 			Limits:        Limits{Min: 2},
 		})).
 		Build()
 
-	instance, err := NewRuntime().
+	instance, err := runtime.
 		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
 	if err != nil {
 		t.Fatalf("failed to instantiate module: %v", err)

--- a/epsilon/table.go
+++ b/epsilon/table.go
@@ -22,16 +22,20 @@ var errTableOutOfBounds = errors.New("out of bounds table access")
 type Table struct {
 	Type     TableType
 	elements []int32
+
+	// owner identifies which vm and therefore which runtime this instance
+	// belongs to.
+	owner *vm
 }
 
-// NewTable creates a new Table instance from a TableType.
+// newTable creates a new Table instance from a TableType.
 // The table is initialized with 'NullReference' elements up to the min size.
-func NewTable(tt TableType) *Table {
+func newTable(owner *vm, tt TableType) *Table {
 	elements := make([]int32, tt.Limits.Min)
 	for i := range elements {
 		elements[i] = NullReference
 	}
-	return &Table{Type: tt, elements: elements}
+	return &Table{owner: owner, Type: tt, elements: elements}
 }
 
 // Get returns the element at the given index.

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -159,20 +159,17 @@ func (vm *vm) instantiate(
 		vm.store.globals = append(vm.store.globals, global)
 	}
 
-	for _, global := range module.globalVariables {
-		val, err := vm.invokeExpression(
-			global.initExpression,
-			global.globalType.ValueType,
-			moduleInstance,
-		)
+	for _, variable := range module.globalVariables {
+		valueType := variable.globalType.ValueType
+		initExpression := variable.initExpression
+		val, err := vm.invokeExpression(initExpression, valueType, moduleInstance)
 		if err != nil {
 			return nil, err
 		}
 
 		storeIndex := uint32(len(vm.store.globals))
 		moduleInstance.globalAddrs = append(moduleInstance.globalAddrs, storeIndex)
-		isMutable := global.globalType.IsMutable
-		global := newGlobal(vm, val, isMutable, global.globalType.ValueType)
+		global := newGlobal(vm, val, variable.globalType.IsMutable, valueType)
 		vm.store.globals = append(vm.store.globals, global)
 	}
 

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -135,7 +135,7 @@ func (vm *vm) instantiate(
 
 	for _, tableType := range module.tables {
 		storeIndex := uint32(len(vm.store.tables))
-		table := NewTable(tableType)
+		table := newTable(vm, tableType)
 		moduleInstance.tableAddrs = append(moduleInstance.tableAddrs, storeIndex)
 		vm.store.tables = append(vm.store.tables, table)
 	}
@@ -148,7 +148,7 @@ func (vm *vm) instantiate(
 
 	for _, memoryType := range module.memories {
 		storeIndex := uint32(len(vm.store.memories))
-		memory := NewMemory(memoryType)
+		memory := newMemory(vm, memoryType)
 		moduleInstance.memAddrs = append(moduleInstance.memAddrs, storeIndex)
 		vm.store.memories = append(vm.store.memories, memory)
 	}
@@ -171,11 +171,9 @@ func (vm *vm) instantiate(
 
 		storeIndex := uint32(len(vm.store.globals))
 		moduleInstance.globalAddrs = append(moduleInstance.globalAddrs, storeIndex)
-		vm.store.globals = append(vm.store.globals, &Global{
-			value:   val,
-			Mutable: global.globalType.IsMutable,
-			Type:    global.globalType.ValueType,
-		})
+		isMutable := global.globalType.IsMutable
+		global := newGlobal(vm, val, isMutable, global.globalType.ValueType)
+		vm.store.globals = append(vm.store.globals, global)
 	}
 
 	// TODO: elements and data segments should at the very least be copied, but we

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -851,18 +851,13 @@ func TestHostFunctionResultCountMismatch(t *testing.T) {
 
 func TestGlobalGet(t *testing.T) {
 	wat := `(module
-		(import "module" "global" (global $g i32))
+		(global $g i32 (i32.const 42))
 
 		(func (export "test") (result i32)
 			global.get $g
 		)
 	)`
-	imports := map[string]map[string]any{
-		"module": {
-			"global": int32(42),
-		},
-	}
-	moduleInstance, err := instantiate(wat, imports, nil)
+	moduleInstance, err := instantiate(wat, nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)
 	}

--- a/internal/spec_tests/spec_test_runner.go
+++ b/internal/spec_tests/spec_test_runner.go
@@ -34,7 +34,7 @@ type specTestRunner struct {
 	runtime            *epsilon.Runtime
 	moduleInstanceMap  map[string]*epsilon.ModuleInstance
 	lastModuleInstance *epsilon.ModuleInstance
-	spectestImports    map[string]map[string]any
+	spectestImports    *epsilon.ModuleImports
 }
 
 func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
@@ -42,7 +42,7 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 	tableLimitMax := uint32(20)
 
 	runtime := epsilon.NewRuntime()
-	spectestImports := epsilon.NewModuleImportBuilder("spectest").
+	spectestImports := epsilon.NewModuleImports("spectest").
 		AddGlobal("global_i32", runtime.NewGlobalI32(666, false)).
 		AddGlobal("global_i64", runtime.NewGlobalI64(666, false)).
 		AddGlobal("global_f32", runtime.NewGlobalF32(666.6, false)).
@@ -108,8 +108,7 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 		AddHostFunc("print", func(m *epsilon.ModuleInstance, args ...any) []any {
 			fmt.Printf("Print called!")
 			return nil
-		}).
-		Build()
+		})
 
 	return &specTestRunner{
 		t:                 t,
@@ -168,12 +167,11 @@ func (r *specTestRunner) handleRegister(cmd wabt.Command) {
 	r.moduleInstanceMap[cmd.As] = r.lastModuleInstance
 }
 
-func (r *specTestRunner) buildImports() []map[string]map[string]any {
-	imports := []map[string]map[string]any{r.spectestImports}
+func (r *specTestRunner) buildImports() []*epsilon.ModuleImports {
+	imports := []*epsilon.ModuleImports{r.spectestImports}
 	for regName, moduleInstance := range r.moduleInstanceMap {
-		moduleImport := epsilon.NewModuleImportBuilder(regName).
-			AddModuleExports(moduleInstance).
-			Build()
+		moduleImport := epsilon.NewModuleImports(regName).
+			AddModuleExports(moduleInstance)
 		imports = append(imports, moduleImport)
 	}
 	return imports

--- a/internal/spec_tests/spec_test_runner.go
+++ b/internal/spec_tests/spec_test_runner.go
@@ -41,16 +41,17 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 	importMemoryLimitMax := uint32(2)
 	tableLimitMax := uint32(20)
 
+	runtime := epsilon.NewRuntime()
 	spectestImports := epsilon.NewModuleImportBuilder("spectest").
-		AddGlobal("global_i32", int32(666), false, epsilon.I32).
-		AddGlobal("global_i64", int64(666), false, epsilon.I64).
-		AddGlobal("global_f32", float32(666.6), false, epsilon.F32).
-		AddGlobal("global_f64", float64(666.6), false, epsilon.F64).
-		AddTable("table", epsilon.NewTable(epsilon.TableType{
+		AddGlobal("global_i32", runtime.NewGlobalI32(666, false)).
+		AddGlobal("global_i64", runtime.NewGlobalI64(666, false)).
+		AddGlobal("global_f32", runtime.NewGlobalF32(666.6, false)).
+		AddGlobal("global_f64", runtime.NewGlobalF64(666.6, false)).
+		AddTable("table", runtime.NewTable(epsilon.TableType{
 			Limits:        epsilon.Limits{Min: 10, Max: &tableLimitMax},
 			ReferenceType: epsilon.FuncRefType,
 		})).
-		AddMemory("memory", epsilon.NewMemory(
+		AddMemory("memory", runtime.NewMemory(
 			epsilon.MemoryType{
 				Limits: epsilon.Limits{Min: 1, Max: &importMemoryLimitMax},
 			},
@@ -113,7 +114,7 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 	return &specTestRunner{
 		t:                 t,
 		wasmDict:          wasmDict,
-		runtime:           epsilon.NewRuntime(),
+		runtime:           runtime,
 		moduleInstanceMap: make(map[string]*epsilon.ModuleInstance),
 		spectestImports:   spectestImports,
 	}

--- a/wasip1/wasi_clocks_test.go
+++ b/wasip1/wasi_clocks_test.go
@@ -47,7 +47,8 @@ func TestClocks_Consistency(t *testing.T) {
 }
 
 func TestClocks_TimeGetConsistency(t *testing.T) {
-	mem := epsilon.NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
+	mem := epsilon.NewRuntime().
+		NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
 	w := &WasiModule{monotonicClockStart: time.Now()}
 
 	// Verify clock_res_get consistency with clock_time_get for CPU clocks

--- a/wasip1/wasi_resources_test.go
+++ b/wasip1/wasi_resources_test.go
@@ -64,7 +64,8 @@ func TestRightsEscalation_FdFilestatGet(t *testing.T) {
 	}
 	defer f.Close()
 
-	mem := epsilon.NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
+	mem := epsilon.NewRuntime().
+		NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
 	rt := &wasiResourceTable{
 		fds: map[int32]*wasiFileDescriptor{
 			3: {
@@ -132,7 +133,8 @@ func TestRightsEscalation_SockAccept_Inheritance(t *testing.T) {
 	}
 	defer file.Close()
 
-	mem := epsilon.NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
+	mem := epsilon.NewRuntime().
+		NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
 
 	// Define a custom right to see if it's NOT inherited if not in
 	// rightsInheriting.
@@ -166,7 +168,8 @@ func TestRightsEscalation_SockAccept_Inheritance(t *testing.T) {
 }
 
 func TestPollOneoff_ClockOverflow(t *testing.T) {
-	mem := epsilon.NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
+	mem := epsilon.NewRuntime().
+		NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})
 	w := &WasiModule{
 		monotonicClockStart: time.Now(), // now - start = now - 1
 	}

--- a/wasip1/wasi_stub.go
+++ b/wasip1/wasi_stub.go
@@ -19,6 +19,8 @@ package wasip1
 import (
 	"errors"
 	"os"
+
+	"github.com/ziggy42/epsilon/epsilon"
 )
 
 // WasiModuleBuilder is a builder for creating WasiModule instances.
@@ -96,6 +98,8 @@ func (b *WasiModuleBuilder) Build() (*WasiModule, error) {
 	return nil, errors.New("WASI is not supported on this platform")
 }
 
-func (w *WasiModule) ToImports() map[string]map[string]any { return nil }
+func (w *WasiModule) ToImports() *epsilon.ModuleImports {
+	return epsilon.NewModuleImports(ModuleName)
+}
 
 func (w *WasiModule) Close() {}

--- a/wasip1/wasi_unix.go
+++ b/wasip1/wasi_unix.go
@@ -314,8 +314,8 @@ func bindMem(
 	}
 }
 
-func (w *WasiModule) ToImports() map[string]map[string]any {
-	return epsilon.NewModuleImportBuilder(ModuleName).
+func (w *WasiModule) ToImports() *epsilon.ModuleImports {
+	return epsilon.NewModuleImports(ModuleName).
 		AddHostFunc("args_get", bindMem(func(m *epsilon.Memory, args []any) int32 {
 			return w.argsGet(m, args[0].(int32), args[1].(int32))
 		})).
@@ -687,8 +687,7 @@ func (w *WasiModule) ToImports() map[string]map[string]any {
 		})).
 		AddHostFunc("sock_shutdown", bind(func(args []any) int32 {
 			return w.fs.sockShutdown(args[0].(int32), args[1].(int32))
-		})).
-		Build()
+		}))
 }
 
 // Close releases all resources held by the WasiModule, including file


### PR DESCRIPTION
Fixes a critical isolation vulnerability where `Memory`, `Table`, `Global`, and  `Function` objects could be shared across separate `Runtime` instances. The WebAssembly  spec assumes a single store per abstract machine; mixing objects across runtimes breaks  isolation and can lead to state corruption, information leakage, and unauthorized  execution of private functions via shared tables.

## Root Cause
`resolveMemoryImport`, `resolveTableImport`, `resolveGlobalImport`, and  `resolveFunctionImport` in `imports.go` performed no cross-runtime validation. Any exported object from runtime A could be passed as an import to a module in  runtime B without error.

## Changes
- Added an unexported `owner *vm` field to `Memory`, `Table`, and `Global`. This field is stamped at construction time by package-internal constructors and cannot be forged by callers outside the package.
- All four `resolve*Import` functions now reject imports where the object's owning `vm` differs from the importing module's `vm`.
- `vm` is now initialized eagerly in `NewRuntime()` (previously lazy) so ownership can be stamped before any module is instantiated.
- The `Runtime` exposes typed factory methods (`NewMemory`, `NewTable`, `NewGlobal`, `NewGlobalI32/I64/F32/F64`) so callers can create host-side objects with correct ownership without accessing internal types.

## API changes
`ModuleImportBuilder` is renamed to `ModuleImports`, `.Build()` is removed, and host-side objects must now be created through the `Runtime` so ownership is stamped correctly. `AddGlobal` no longer accepts raw values.

Before:
```go
imports := epsilon.NewModuleImportBuilder("env").
  AddMemory("mem", epsilon.NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})).
  AddGlobal("offset", int32(1024), false, epsilon.I32).
  Build()

instance, err := epsilon.NewRuntime().
  InstantiateModuleWithImports(wasmReader, imports)
```

After:
```go
runtime := epsilon.NewRuntime()

imports := epsilon.NewModuleImports("env").
  AddMemory("mem", runtime.NewMemory(epsilon.MemoryType{Limits: epsilon.Limits{Min: 1}})).
  AddGlobal("offset", runtime.NewGlobalI32(1024, false))

instance, err := runtime.InstantiateModuleWithImports(wasmReader, imports)
```