### PR TITLE
Fix WASI rights bypass in pread, pwrite, and poll_oneoff

### DIFF
--- a/wasip1/wasi_poll.go
+++ b/wasip1/wasi_poll.go
@@ -163,7 +163,14 @@ func (w *WasiModule) handleClockSubscription(
 func (w *WasiModule) handleFdSubscription(sub subscription) *event {
 	fdSub := parseSubscriptionFdReadwrite(sub.body)
 
-	fd, errCode := w.fs.getFileOrDir(int32(fdSub.fd), RightsPollFdReadwrite)
+	eventRights := RightsPollFdReadwrite
+	if sub.subscriptionType == eventTypeFdRead {
+		eventRights |= RightsFdRead
+	} else {
+		eventRights |= RightsFdWrite
+	}
+
+	fd, errCode := w.fs.getFileOrDir(int32(fdSub.fd), eventRights)
 	if errCode != errnoSuccess {
 		return &event{
 			userData:  sub.userData,
@@ -184,7 +191,7 @@ func (w *WasiModule) handleFdSubscription(sub subscription) *event {
 	}
 
 	var nbytes uint64
-	if fd.fileType == fileTypeRegularFile {
+	if fd.fileType == fileTypeRegularFile && fd.rights&RightsFdFilestatGet != 0 {
 		if info, err := fd.file.Stat(); err == nil {
 			nbytes = uint64(info.Size())
 		}

--- a/wasip1/wasi_resources.go
+++ b/wasip1/wasi_resources.go
@@ -304,7 +304,7 @@ func (w *wasiResourceTable) pread(
 	offset int64,
 	nPtr int32,
 ) int32 {
-	fd, errCode := w.getFile(fdIndex, RightsFdRead)
+	fd, errCode := w.getFile(fdIndex, RightsFdRead|RightsFdSeek)
 	if errCode != errnoSuccess {
 		return errCode
 	}
@@ -368,7 +368,7 @@ func (w *wasiResourceTable) pwrite(
 	offset int64,
 	nPtr int32,
 ) int32 {
-	fd, errCode := w.getFile(fdIndex, RightsFdWrite)
+	fd, errCode := w.getFile(fdIndex, RightsFdWrite|RightsFdSeek)
 	if errCode != errnoSuccess {
 		return errCode
 	}


### PR DESCRIPTION
## Summary

- `fd_pread` and `fd_pwrite` only checked `RightsFdRead`/`RightsFdWrite` but the WASI spec requires `RightsFdSeek` for both since they take an explicit offset (non-sequential access). Added the missing `RightsFdSeek` check to both.
- `poll_oneoff` only checked `RightsPollFdReadwrite` regardless of event type. Now also checks `RightsFdRead` for read subscriptions and `RightsFdWrite` for write subscriptions.
- `poll_oneoff` was unconditionally calling `Stat()` and returning the file size in `nbytes` even for modules lacking `RightsFdFilestatGet`. Gated that behind the capability check — `nbytes` returns 0 when the right is absent rather than leaking metadata or erroring on an otherwise valid poll.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] Official WASI testsuite (`uv run --with-requirements requirements.txt wasip1/wasi_testsuite.py`) — 72 tests pass, 17 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)