### PR TITLE
Cap attacker-controlled pre-allocations in the parser

### DIFF
--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -52,6 +52,13 @@ const (
 	sixthBitMask         = uint64(1 << 6)
 )
 
+// initialVectorCapacity caps the up-front allocation parseVector and similar
+// callers perform from an attacker-controlled count. Real modules rarely
+// exceed a few thousand items per vector, so this is the common-case exact
+// size; pathological counts grow via append+EOF instead of OOMing on a
+// pre-allocation.
+const initialVectorCapacity = 4096
+
 // sectionId represents the different sections of a WebAssembly module.
 // See https://webassembly.github.io/spec/core/binary/modules.html#sections
 type sectionId byte
@@ -753,13 +760,6 @@ func (p *parser) parseLimits() (Limits, error) {
 		return Limits{}, errInvalidLimitsFormat
 	}
 }
-
-// initialVectorCapacity caps the up-front allocation parseVector and similar
-// callers perform from an attacker-controlled count. Real modules rarely
-// exceed a few thousand items per vector, so this is the common-case exact
-// size; pathological counts grow via append+EOF instead of OOMing on a
-// pre-allocation.
-const initialVectorCapacity = 1 << 12
 
 func parseVector[T any](parser *parser, parse func() (T, error)) ([]T, error) {
 	count, err := parser.parseUint32()

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -266,11 +266,13 @@ func (p *parser) parseCustomSection(payloadLen uint32) error {
 		return errIntegerTooLarge
 	}
 
-	nameBytes := make([]byte, nameLength)
-	if _, err := io.ReadFull(p.reader, nameBytes); err != nil {
+	nameBytes := bytes.NewBuffer(
+		make([]byte, 0, min(nameLength, initialVectorCapacity)),
+	)
+	if _, err := io.CopyN(nameBytes, p.reader, int64(nameLength)); err != nil {
 		return err
 	}
-	if !utf8.Valid(nameBytes) {
+	if !utf8.Valid(nameBytes.Bytes()) {
 		return errInvalidUTF8
 	}
 
@@ -798,11 +800,11 @@ func (p *parser) parseUtf8String() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	buf := make([]byte, length)
-	if _, err := io.ReadFull(p.reader, buf); err != nil {
+	buf := bytes.NewBuffer(make([]byte, 0, min(length, initialVectorCapacity)))
+	if _, err := io.CopyN(buf, p.reader, int64(length)); err != nil {
 		return "", fmt.Errorf("failed to read string bytes: %w", err)
 	}
-	return string(buf), nil
+	return buf.String(), nil
 }
 
 func uint64SliceToInt32(slice []uint64) []int32 {
@@ -1154,13 +1156,13 @@ func (p *parser) readImmediateVector() ([]uint64, error) {
 		return nil, err
 	}
 
-	immediates := make([]uint64, size)
-	for i := range size {
+	immediates := make([]uint64, 0, min(size, initialVectorCapacity))
+	for range size {
 		val, err := p.readUint32()
 		if err != nil {
 			return nil, err
 		}
-		immediates[i] = val
+		immediates = append(immediates, val)
 	}
 	return immediates, nil
 }

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -299,7 +299,7 @@ func (p *parser) parseFunction() (function, error) {
 		return function{}, fmt.Errorf("too many locals: %d", totalLocalsCount)
 	}
 
-	locals := make([]ValueType, 0, totalLocalsCount)
+	locals := make([]ValueType, 0, min(totalLocalsCount, initialVectorCapacity))
 	for _, entry := range localEntries {
 		for i := uint64(0); i < entry.count; i++ {
 			locals = append(locals, entry.typ)
@@ -754,18 +754,25 @@ func (p *parser) parseLimits() (Limits, error) {
 	}
 }
 
+// initialVectorCapacity caps the up-front allocation parseVector and similar
+// callers perform from an attacker-controlled count. Real modules rarely
+// exceed a few thousand items per vector, so this is the common-case exact
+// size; pathological counts grow via append+EOF instead of OOMing on a
+// pre-allocation.
+const initialVectorCapacity = 1 << 12
+
 func parseVector[T any](parser *parser, parse func() (T, error)) ([]T, error) {
 	count, err := parser.parseUint32()
 	if err != nil {
 		return nil, err
 	}
-	items := make([]T, count)
-	for i := 0; i < int(count); i++ {
+	items := make([]T, 0, min(count, initialVectorCapacity))
+	for i := uint32(0); i < count; i++ {
 		parsed, err := parse()
 		if err != nil {
 			return nil, err
 		}
-		items[i] = parsed
+		items = append(items, parsed)
 	}
 	return items, nil
 }


### PR DESCRIPTION
## Summary

Several parser sites took a count parsed directly from the WASM binary and fed it into `make()` with no bound beyond `math.MaxUint32`. A few-byte module could request multi-GB allocations and OOM the host before the missing bytes were ever read.

This PR introduces a shared `initialVectorCapacity = 4096` and applies the same defense to every affected site:

- `parseVector[T]`, `parseFunction` (locals), `readImmediateVector` — `make([]T, 0, min(count, cap))` + `append`, so the inner `parse()`/`read()` hits `ErrUnexpectedEOF` long before runaway growth.
- `parseCustomSection`, `parseUtf8String` — switch from `make([]byte, length)` + `io.ReadFull` to `bytes.NewBuffer(make([]byte, 0, min(length, cap)))` + `io.CopyN`, so the buffer grows organically up to the bytes actually delivered.

4096 is the common-case exact size for real modules; pathological counts grow geometrically via `append` instead of pre-allocating gigabytes.

## Test plan

- [x] `go build` for linux/darwin/windows
- [x] `go vet ./...`
- [x] `go test ./...` (incl. `internal/spec_tests` and `wasip1`)
- [x] `uv run wasip1/wasi_testsuite.py` — 72 pass / 17 skipped
- [x] `internal/benchmarks/compare.py` — no regressions on hot paths