### PR TITLE
Add configurable resource limits to Config

### DIFF
--- a/epsilon/config.go
+++ b/epsilon/config.go
@@ -14,15 +14,27 @@
 
 package epsilon
 
+// Default values for each Config field. Exposed so callers can construct a
+// Config literal that names the defaults explicitly for the fields it does
+// not want to override.
+const (
+	DefaultMaxCallStackDepth          = 1000
+	DefaultCallStackPreallocationSize = 1000
+	DefaultMaxTableElements           = 10_000_000
+	DefaultMaxMemoryPages             = 65536
+	DefaultMaxLocalsPerFunction       = 50_000
+)
+
 // Config controls the behavior and resource limits of the VM.
 type Config struct {
 	// MaxCallStackDepth is the hard limit on call stack depth to prevent
-	// infinite recursion. Default: 1000.
+	// infinite recursion. Default: DefaultMaxCallStackDepth.
 	MaxCallStackDepth int
 
-	// CallStackPreallocationSize controls how many call frames to preallocate.
-	// Caches (controlStackCache, localsCache) are sized to this value.
-	// Beyond this depth, allocations fall back to heap. Default: 1000.
+	// CallStackPreallocationSize controls how many call frames to
+	// preallocate. Caches (controlStackCache, localsCache) are sized to
+	// this value. Beyond this depth, allocations fall back to heap.
+	// Default: DefaultCallStackPreallocationSize.
 	CallStackPreallocationSize int
 
 	// ExperimentalMultipleMemories enables WASM 3.0 multiple memories.
@@ -30,9 +42,10 @@ type Config struct {
 	// See https://github.com/WebAssembly/wabt/issues/2648. Default: false.
 	ExperimentalMultipleMemories bool
 
-	// EnableFuel enables instruction fuel (gas) mechanism to prevent infinite
-	// loops and control execution time. When enabled, the VM will decrement
-	// the available fuel by 1 for every WASM instruction executed.
+	// EnableFuel enables instruction fuel (gas) mechanism to prevent
+	// infinite loops and control execution time. When enabled, the VM will
+	// decrement the available fuel by 1 for every WASM instruction
+	// executed.
 	// NOTE: Enabling fuel has a non-trivial performance impact on the VM.
 	// Default: false.
 	EnableFuel bool
@@ -45,30 +58,33 @@ type Config struct {
 	// MaxTableElements is the upper bound on a declared table's Limits.Min
 	// (and Limits.Max, if present). A module declaring a table above this
 	// ceiling is rejected during validation. The spec permits up to 2^32-1
-	// elements, but each element is reference-sized, so hosts almost always
-	// want a much smaller cap. Default: 10_000_000.
+	// elements, but each element is reference-sized, so hosts almost
+	// always want a much smaller cap. Default: DefaultMaxTableElements.
 	MaxTableElements uint32
 
 	// MaxMemoryPages is the upper bound on a declared memory's Limits.Min
 	// (and Limits.Max, if present), expressed in 64 KiB WebAssembly pages.
 	// A module declaring a memory above this ceiling is rejected during
-	// validation. Default: 65536 (= 4 GiB, the WebAssembly 32-bit maximum).
+	// validation. Default: DefaultMaxMemoryPages (= 4 GiB, the
+	// WebAssembly 32-bit maximum).
 	MaxMemoryPages uint32
 
-	// MaxLocalsPerFunction is the upper bound on the total number of declared
-	// locals (sum of all local entry counts) for a single function body.
-	// Function parameters are not counted. A function exceeding this ceiling
-	// is rejected during parsing. Default: 50_000.
+	// MaxLocalsPerFunction is the upper bound on the total number of
+	// declared locals (sum of all local entry counts) for a single
+	// function body. Function parameters are not counted. A function
+	// exceeding this ceiling is rejected during parsing. Default:
+	// DefaultMaxLocalsPerFunction.
 	MaxLocalsPerFunction uint32
 }
 
-// DefaultConfig returns a Config with sensible defaults.
+// DefaultConfig returns a Config with every field set to its corresponding
+// Default* constant.
 func DefaultConfig() Config {
 	return Config{
-		MaxCallStackDepth:          1000,
-		CallStackPreallocationSize: 1000,
-		MaxTableElements:           10_000_000,
-		MaxMemoryPages:             65536,
-		MaxLocalsPerFunction:       50_000,
+		MaxCallStackDepth:          DefaultMaxCallStackDepth,
+		CallStackPreallocationSize: DefaultCallStackPreallocationSize,
+		MaxTableElements:           DefaultMaxTableElements,
+		MaxMemoryPages:             DefaultMaxMemoryPages,
+		MaxLocalsPerFunction:       DefaultMaxLocalsPerFunction,
 	}
 }

--- a/epsilon/config.go
+++ b/epsilon/config.go
@@ -14,7 +14,6 @@
 
 package epsilon
 
-// Default values for each Config field.
 const (
 	DefaultMaxCallStackDepth          = 1000
 	DefaultCallStackPreallocationSize = 1000
@@ -26,18 +25,20 @@ const (
 // Config controls the behavior and resource limits of the VM.
 type Config struct {
 	// MaxCallStackDepth is the hard limit on call stack depth to prevent
-	// infinite recursion. Default: DefaultMaxCallStackDepth.
+	// infinite recursion.
+	// Default: DefaultMaxCallStackDepth.
 	MaxCallStackDepth int
 
-	// CallStackPreallocationSize controls how many call frames to
-	// preallocate. Caches (controlStackCache, localsCache) are sized to
-	// this value. Beyond this depth, allocations fall back to heap.
+	// CallStackPreallocationSize controls how many call frames to preallocate.
+	// Caches (controlStackCache, localsCache) are sized to this value.
+	// Beyond this depth, allocations fall back to heap.
 	// Default: DefaultCallStackPreallocationSize.
 	CallStackPreallocationSize int
 
 	// ExperimentalMultipleMemories enables WASM 3.0 multiple memories.
 	// This feature has not yet been fully validated with spec tests.
-	// See https://github.com/WebAssembly/wabt/issues/2648. Default: false.
+	// See https://github.com/WebAssembly/wabt/issues/2648.
+	// Default: false.
 	ExperimentalMultipleMemories bool
 
 	// EnableFuel enables instruction fuel (gas) mechanism to prevent infinite
@@ -52,22 +53,22 @@ type Config struct {
 	// Only used if EnableFuel is true.
 	Fuel uint64
 
-	// MaxTableElements is the upper bound on a declared table's Limits.Min
-	// (and Limits.Max, if present). A module declaring a table above this
-	// ceiling is rejected. Default: DefaultMaxTableElements.
+	// MaxTableElements is the upper bound on a declared table's Limits.Min (and
+	// Limits.Max, if present). A module declaring a table above this ceiling is
+	// rejected.
+	// Default: DefaultMaxTableElements.
 	MaxTableElements uint32
 
-	// MaxMemoryPages is the upper bound on a declared memory's Limits.Min
-	// (and Limits.Max, if present), expressed in 64 KiB WebAssembly pages.
-	// A module declaring a memory above this ceiling is rejected.
-	// Default: DefaultMaxMemoryPages (= 4 GiB, the WebAssembly 32-bit
-	// maximum).
+	// MaxMemoryPages is the upper bound on a declared memory's Limits.Min (and
+	// Limits.Max, if present), expressed in 64 KiB WebAssembly pages. A module
+	// declaring a memory above this ceiling is rejected.
+	// Default: DefaultMaxMemoryPages (= 4 GiB, the WebAssembly 32-bit maximum).
 	MaxMemoryPages uint32
 
-	// MaxLocalsPerFunction is the upper bound on the total number of
-	// declared locals (sum of all local entry counts) for a single
-	// function body. Function parameters are not counted. A function
-	// exceeding this ceiling is rejected.
+	// MaxLocalsPerFunction is the upper bound on the total number of declared
+	// locals (sum of all local entry counts) for a single function body.
+	// Function parameters are not counted. A function exceeding this ceiling is
+	// rejected.
 	// Default: DefaultMaxLocalsPerFunction.
 	MaxLocalsPerFunction uint32
 }

--- a/epsilon/config.go
+++ b/epsilon/config.go
@@ -14,9 +14,7 @@
 
 package epsilon
 
-// Default values for each Config field. Exposed so callers can construct a
-// Config literal that names the defaults explicitly for the fields it does
-// not want to override.
+// Default values for each Config field.
 const (
 	DefaultMaxCallStackDepth          = 1000
 	DefaultCallStackPreallocationSize = 1000
@@ -42,10 +40,9 @@ type Config struct {
 	// See https://github.com/WebAssembly/wabt/issues/2648. Default: false.
 	ExperimentalMultipleMemories bool
 
-	// EnableFuel enables instruction fuel (gas) mechanism to prevent
-	// infinite loops and control execution time. When enabled, the VM will
-	// decrement the available fuel by 1 for every WASM instruction
-	// executed.
+	// EnableFuel enables instruction fuel (gas) mechanism to prevent infinite
+	// loops and control execution time. When enabled, the VM will decrement
+	// the available fuel by 1 for every WASM instruction executed.
 	// NOTE: Enabling fuel has a non-trivial performance impact on the VM.
 	// Default: false.
 	EnableFuel bool
@@ -57,23 +54,21 @@ type Config struct {
 
 	// MaxTableElements is the upper bound on a declared table's Limits.Min
 	// (and Limits.Max, if present). A module declaring a table above this
-	// ceiling is rejected during validation. The spec permits up to 2^32-1
-	// elements, but each element is reference-sized, so hosts almost
-	// always want a much smaller cap. Default: DefaultMaxTableElements.
+	// ceiling is rejected. Default: DefaultMaxTableElements.
 	MaxTableElements uint32
 
 	// MaxMemoryPages is the upper bound on a declared memory's Limits.Min
 	// (and Limits.Max, if present), expressed in 64 KiB WebAssembly pages.
-	// A module declaring a memory above this ceiling is rejected during
-	// validation. Default: DefaultMaxMemoryPages (= 4 GiB, the
-	// WebAssembly 32-bit maximum).
+	// A module declaring a memory above this ceiling is rejected.
+	// Default: DefaultMaxMemoryPages (= 4 GiB, the WebAssembly 32-bit
+	// maximum).
 	MaxMemoryPages uint32
 
 	// MaxLocalsPerFunction is the upper bound on the total number of
 	// declared locals (sum of all local entry counts) for a single
 	// function body. Function parameters are not counted. A function
-	// exceeding this ceiling is rejected during parsing. Default:
-	// DefaultMaxLocalsPerFunction.
+	// exceeding this ceiling is rejected.
+	// Default: DefaultMaxLocalsPerFunction.
 	MaxLocalsPerFunction uint32
 }
 

--- a/epsilon/config.go
+++ b/epsilon/config.go
@@ -41,6 +41,25 @@ type Config struct {
 	// One unit of fuel equals one WASM instruction.
 	// Only used if EnableFuel is true.
 	Fuel uint64
+
+	// MaxTableElements is the upper bound on a declared table's Limits.Min
+	// (and Limits.Max, if present). A module declaring a table above this
+	// ceiling is rejected during validation. The spec permits up to 2^32-1
+	// elements, but each element is reference-sized, so hosts almost always
+	// want a much smaller cap. Default: 10_000_000.
+	MaxTableElements uint32
+
+	// MaxMemoryPages is the upper bound on a declared memory's Limits.Min
+	// (and Limits.Max, if present), expressed in 64 KiB WebAssembly pages.
+	// A module declaring a memory above this ceiling is rejected during
+	// validation. Default: 65536 (= 4 GiB, the WebAssembly 32-bit maximum).
+	MaxMemoryPages uint32
+
+	// MaxLocalsPerFunction is the upper bound on the total number of declared
+	// locals (sum of all local entry counts) for a single function body.
+	// Function parameters are not counted. A function exceeding this ceiling
+	// is rejected during parsing. Default: 50_000.
+	MaxLocalsPerFunction uint32
 }
 
 // DefaultConfig returns a Config with sensible defaults.
@@ -48,5 +67,8 @@ func DefaultConfig() Config {
 	return Config{
 		MaxCallStackDepth:          1000,
 		CallStackPreallocationSize: 1000,
+		MaxTableElements:           10_000_000,
+		MaxMemoryPages:             65536,
+		MaxLocalsPerFunction:       50_000,
 	}
 }

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -90,11 +90,7 @@ type parser struct {
 	config Config
 }
 
-func newParser(reader io.Reader) *parser {
-	return newParserWithConfig(reader, DefaultConfig())
-}
-
-func newParserWithConfig(reader io.Reader, config Config) *parser {
+func newParser(reader io.Reader, config Config) *parser {
 	return &parser{reader: bufio.NewReader(reader), config: config}
 }
 

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -87,10 +87,15 @@ type localEntry struct {
 // parser is a parser for WASM modules.
 type parser struct {
 	reader *bufio.Reader
+	config Config
 }
 
 func newParser(reader io.Reader) *parser {
-	return &parser{reader: bufio.NewReader(reader)}
+	return newParserWithConfig(reader, DefaultConfig())
+}
+
+func newParserWithConfig(reader io.Reader, config Config) *parser {
+	return &parser{reader: bufio.NewReader(reader), config: config}
 }
 
 // parse takes a byte slice and returns a Module.
@@ -304,8 +309,9 @@ func (p *parser) parseFunction() (function, error) {
 	for _, entry := range localEntries {
 		totalLocalsCount += entry.count
 	}
-	if totalLocalsCount > math.MaxInt32 {
-		return function{}, fmt.Errorf("too many locals: %d", totalLocalsCount)
+	if totalLocalsCount > uint64(p.config.MaxLocalsPerFunction) {
+		return function{}, fmt.Errorf("too many locals: %d exceeds configured limit %d",
+			totalLocalsCount, p.config.MaxLocalsPerFunction)
 	}
 
 	locals := make([]ValueType, 0, min(totalLocalsCount, initialVectorCapacity))

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -310,8 +310,10 @@ func (p *parser) parseFunction() (function, error) {
 		totalLocalsCount += entry.count
 	}
 	if totalLocalsCount > uint64(p.config.MaxLocalsPerFunction) {
-		return function{}, fmt.Errorf("too many locals: %d exceeds configured limit %d",
-			totalLocalsCount, p.config.MaxLocalsPerFunction)
+		return function{}, fmt.Errorf(
+			"too many locals: %d exceeds configured limit %d",
+			totalLocalsCount, p.config.MaxLocalsPerFunction,
+		)
 	}
 
 	locals := make([]ValueType, 0, min(totalLocalsCount, initialVectorCapacity))

--- a/epsilon/parser_test.go
+++ b/epsilon/parser_test.go
@@ -28,7 +28,7 @@ func parseModule(wat string) (moduleDefinition, error) {
 	if err != nil {
 		return moduleDefinition{}, err
 	}
-	module, err := newParser(bytes.NewReader(wasm)).parse()
+	module, err := newParser(bytes.NewReader(wasm), DefaultConfig()).parse()
 	if err != nil {
 		return moduleDefinition{}, err
 	}
@@ -479,7 +479,7 @@ func TestParseTruncatedFunctionBody(t *testing.T) {
 		0x0a, 0x05, 0x01, 0x03, 0x00, 0x41, 0x0b, // i32.const 0x0B (truncated)
 	}
 
-	p := newParser(bytes.NewReader(wasm))
+	p := newParser(bytes.NewReader(wasm), DefaultConfig())
 	_, err := p.parse()
 	if err == nil {
 		t.Fatal("expected parse error for truncated function body, got nil")

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -92,7 +92,7 @@ func (r *Runtime) InstantiateModuleWithImports(
 	wasm io.Reader,
 	imports ...*ModuleImports,
 ) (*ModuleInstance, error) {
-	module, err := newParser(wasm).parse()
+	module, err := newParserWithConfig(wasm, r.config).parse()
 	if err != nil {
 		return nil, err
 	}

--- a/epsilon/runtime.go
+++ b/epsilon/runtime.go
@@ -92,7 +92,7 @@ func (r *Runtime) InstantiateModuleWithImports(
 	wasm io.Reader,
 	imports ...*ModuleImports,
 ) (*ModuleInstance, error) {
-	module, err := newParserWithConfig(wasm, r.config).parse()
+	module, err := newParser(wasm, r.config).parse()
 	if err != nil {
 		return nil, err
 	}

--- a/epsilon/validation.go
+++ b/epsilon/validation.go
@@ -17,7 +17,6 @@ package epsilon
 import (
 	"errors"
 	"fmt"
-	"math"
 )
 
 var (
@@ -145,14 +144,14 @@ func (v *validator) validateModule(module *moduleDefinition) error {
 	}
 
 	for _, table := range module.tables {
-		if err := validateLimits(table.Limits, math.MaxUint32); err != nil {
+		if err := validateLimits(table.Limits, v.config.MaxTableElements); err != nil {
 			return err
 		}
 		v.tableTypes = append(v.tableTypes, table)
 	}
 
 	for _, memoryType := range module.memories {
-		if err := validateLimits(memoryType.Limits, uint32(1)<<16); err != nil {
+		if err := validateLimits(memoryType.Limits, v.config.MaxMemoryPages); err != nil {
 			return err
 		}
 		v.memTypes = append(v.memTypes, memoryType)
@@ -1556,7 +1555,8 @@ func toValueType(code uint64) ValueType {
 
 func validateLimits(limits Limits, maximumRange uint32) error {
 	if limits.Min > maximumRange {
-		return errInvalidLimits
+		return fmt.Errorf("%w: min %d exceeds configured limit %d",
+			errInvalidLimits, limits.Min, maximumRange)
 	}
 
 	if limits.Max == nil {
@@ -1564,7 +1564,8 @@ func validateLimits(limits Limits, maximumRange uint32) error {
 	}
 
 	if *limits.Max > maximumRange {
-		return errInvalidLimits
+		return fmt.Errorf("%w: max %d exceeds configured limit %d",
+			errInvalidLimits, *limits.Max, maximumRange)
 	}
 
 	if limits.Min > *limits.Max {

--- a/epsilon/validation.go
+++ b/epsilon/validation.go
@@ -1557,8 +1557,7 @@ func toValueType(code uint64) ValueType {
 
 func validateLimits(limits Limits, maximumRange uint32) error {
 	if limits.Min > maximumRange {
-		return fmt.Errorf("%w: min %d exceeds configured limit %d",
-			errInvalidLimits, limits.Min, maximumRange)
+		return errInvalidLimits
 	}
 
 	if limits.Max == nil {
@@ -1566,8 +1565,7 @@ func validateLimits(limits Limits, maximumRange uint32) error {
 	}
 
 	if *limits.Max > maximumRange {
-		return fmt.Errorf("%w: max %d exceeds configured limit %d",
-			errInvalidLimits, *limits.Max, maximumRange)
+		return errInvalidLimits
 	}
 
 	if limits.Min > *limits.Max {

--- a/epsilon/validation.go
+++ b/epsilon/validation.go
@@ -144,14 +144,16 @@ func (v *validator) validateModule(module *moduleDefinition) error {
 	}
 
 	for _, table := range module.tables {
-		if err := validateLimits(table.Limits, v.config.MaxTableElements); err != nil {
+		err := validateLimits(table.Limits, v.config.MaxTableElements)
+		if err != nil {
 			return err
 		}
 		v.tableTypes = append(v.tableTypes, table)
 	}
 
 	for _, memoryType := range module.memories {
-		if err := validateLimits(memoryType.Limits, v.config.MaxMemoryPages); err != nil {
+		err := validateLimits(memoryType.Limits, v.config.MaxMemoryPages)
+		if err != nil {
 			return err
 		}
 		v.memTypes = append(v.memTypes, memoryType)

--- a/epsilon/validation_test.go
+++ b/epsilon/validation_test.go
@@ -153,9 +153,14 @@ func TestMemoryIndexValidation(t *testing.T) {
 		t.Fatalf("failed to parse module: %v", err)
 	}
 
-	config := DefaultConfig()
-	config.ExperimentalMultipleMemories = true
-	validator := newValidator(config)
+	validator := newValidator(Config{
+		MaxCallStackDepth:            DefaultMaxCallStackDepth,
+		CallStackPreallocationSize:   DefaultCallStackPreallocationSize,
+		MaxTableElements:             DefaultMaxTableElements,
+		MaxMemoryPages:               DefaultMaxMemoryPages,
+		MaxLocalsPerFunction:         DefaultMaxLocalsPerFunction,
+		ExperimentalMultipleMemories: true,
+	})
 	err = validator.validateModule(module)
 	if err == nil {
 		t.Errorf("expected validation error for OOB memory index, got nil")
@@ -253,7 +258,10 @@ func TestMaxLocalsPerFunctionRejectsOversizedFunction(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "101") ||
 		!strings.Contains(err.Error(), "100") {
-		t.Fatalf("expected error to mention actual count and configured limit, got %v", err)
+		t.Fatalf(
+			"expected error to mention actual count and limit, got %v",
+			err,
+		)
 	}
 
 	_, err = newParserWithConfig(

--- a/epsilon/validation_test.go
+++ b/epsilon/validation_test.go
@@ -28,7 +28,7 @@ func getModule(wat string) (*moduleDefinition, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newParser(bytes.NewReader(wasm)).parse()
+	return newParser(bytes.NewReader(wasm), DefaultConfig()).parse()
 }
 
 func TestInvalidDataUnknownGlobal(t *testing.T) {
@@ -92,7 +92,7 @@ func TestVuln06(t *testing.T) {
 		0x0b, 0x0b, // end of block, end of function
 	}
 
-	module, err := newParser(bytes.NewReader(wasm)).parse()
+	module, err := newParser(bytes.NewReader(wasm), DefaultConfig()).parse()
 	if err != nil {
 		t.Fatalf("failed to parse module: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestNonCanonicalBlockType(t *testing.T) {
 		0x0b, // end of function
 	}
 
-	module, err := newParser(bytes.NewReader(wasm)).parse()
+	module, err := newParser(bytes.NewReader(wasm), DefaultConfig()).parse()
 	if err != nil {
 		t.Fatalf("failed to parse module: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestMemoryIndexValidation(t *testing.T) {
 		0x0b, // end
 	}
 
-	module, err := newParser(bytes.NewReader(wasm)).parse()
+	module, err := newParser(bytes.NewReader(wasm), DefaultConfig()).parse()
 	if err != nil {
 		t.Fatalf("failed to parse module: %v", err)
 	}
@@ -249,10 +249,8 @@ func TestMaxLocalsPerFunctionRejectsOversizedFunction(t *testing.T) {
 		t.Fatalf("failed to assemble wat: %v", err)
 	}
 
-	_, err = newParserWithConfig(
-		bytes.NewReader(wasm),
-		Config{MaxLocalsPerFunction: 100},
-	).parse()
+	config := Config{MaxLocalsPerFunction: 100}
+	_, err = newParser(bytes.NewReader(wasm), config).parse()
 	if err == nil || !strings.Contains(err.Error(), "too many locals") {
 		t.Fatalf("expected too-many-locals error, got %v", err)
 	}
@@ -264,10 +262,8 @@ func TestMaxLocalsPerFunctionRejectsOversizedFunction(t *testing.T) {
 		)
 	}
 
-	_, err = newParserWithConfig(
-		bytes.NewReader(wasm),
-		Config{MaxLocalsPerFunction: 200},
-	).parse()
+	config = Config{MaxLocalsPerFunction: 200}
+	_, err = newParser(bytes.NewReader(wasm), config).parse()
 	if err != nil {
 		t.Fatalf("expected success with raised limit, got %v", err)
 	}

--- a/epsilon/validation_test.go
+++ b/epsilon/validation_test.go
@@ -16,6 +16,8 @@ package epsilon
 
 import (
 	"bytes"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ziggy42/epsilon/internal/wabt"
@@ -39,7 +41,7 @@ func TestInvalidDataUnknownGlobal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse module: %v", err)
 	}
-	validator := newValidator(Config{})
+	validator := newValidator(DefaultConfig())
 
 	err = validator.validateModule(module)
 
@@ -54,7 +56,7 @@ func TestInvalidDataUnknownMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse module: %v", err)
 	}
-	validator := newValidator(Config{})
+	validator := newValidator(DefaultConfig())
 
 	err = validator.validateModule(module)
 
@@ -69,7 +71,7 @@ func TestValidDataMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse module: %v", err)
 	}
-	validator := newValidator(Config{})
+	validator := newValidator(DefaultConfig())
 
 	err = validator.validateModule(module)
 
@@ -94,7 +96,7 @@ func TestVuln06(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse module: %v", err)
 	}
-	validator := newValidator(Config{})
+	validator := newValidator(DefaultConfig())
 
 	err = validator.validateModule(module)
 	if err == nil {
@@ -127,7 +129,7 @@ func TestNonCanonicalBlockType(t *testing.T) {
 		t.Fatalf("failed to parse module: %v", err)
 	}
 
-	err = newValidator(Config{}).validateModule(module)
+	err = newValidator(DefaultConfig()).validateModule(module)
 	if err == nil {
 		t.Fatalf("expected validation error for non-canonical block type, got nil")
 	}
@@ -151,9 +153,114 @@ func TestMemoryIndexValidation(t *testing.T) {
 		t.Fatalf("failed to parse module: %v", err)
 	}
 
-	validator := newValidator(Config{ExperimentalMultipleMemories: true})
+	config := DefaultConfig()
+	config.ExperimentalMultipleMemories = true
+	validator := newValidator(config)
 	err = validator.validateModule(module)
 	if err == nil {
 		t.Errorf("expected validation error for OOB memory index, got nil")
+	}
+}
+
+func TestMaxTableElementsRejectsOversizedTable(t *testing.T) {
+	module, err := getModule(`(module (table 1001 funcref))`)
+	if err != nil {
+		t.Fatalf("failed to parse module: %v", err)
+	}
+
+	err = newValidator(Config{MaxTableElements: 1000}).validateModule(module)
+	if !errors.Is(err, errInvalidLimits) {
+		t.Fatalf("expected errInvalidLimits, got %v", err)
+	}
+
+	err = newValidator(Config{MaxTableElements: 2000}).validateModule(module)
+	if err != nil {
+		t.Fatalf("expected success with raised limit, got %v", err)
+	}
+}
+
+func TestMaxTableElementsRejectsOversizedTableMax(t *testing.T) {
+	module, err := getModule(`(module (table 1 2000 funcref))`)
+	if err != nil {
+		t.Fatalf("failed to parse module: %v", err)
+	}
+
+	err = newValidator(Config{MaxTableElements: 1000}).validateModule(module)
+	if !errors.Is(err, errInvalidLimits) {
+		t.Fatalf("expected errInvalidLimits, got %v", err)
+	}
+
+	err = newValidator(Config{MaxTableElements: 5000}).validateModule(module)
+	if err != nil {
+		t.Fatalf("expected success with raised limit, got %v", err)
+	}
+}
+
+func TestMaxMemoryPagesRejectsOversizedMemory(t *testing.T) {
+	module, err := getModule(`(module (memory 101))`)
+	if err != nil {
+		t.Fatalf("failed to parse module: %v", err)
+	}
+
+	err = newValidator(Config{MaxMemoryPages: 100}).validateModule(module)
+	if !errors.Is(err, errInvalidLimits) {
+		t.Fatalf("expected errInvalidLimits, got %v", err)
+	}
+
+	err = newValidator(Config{MaxMemoryPages: 200}).validateModule(module)
+	if err != nil {
+		t.Fatalf("expected success with raised limit, got %v", err)
+	}
+}
+
+func TestMaxMemoryPagesRejectsOversizedMemoryMax(t *testing.T) {
+	module, err := getModule(`(module (memory 1 200))`)
+	if err != nil {
+		t.Fatalf("failed to parse module: %v", err)
+	}
+
+	err = newValidator(Config{MaxMemoryPages: 100}).validateModule(module)
+	if !errors.Is(err, errInvalidLimits) {
+		t.Fatalf("expected errInvalidLimits, got %v", err)
+	}
+
+	err = newValidator(Config{MaxMemoryPages: 300}).validateModule(module)
+	if err != nil {
+		t.Fatalf("expected success with raised limit, got %v", err)
+	}
+}
+
+func TestMaxLocalsPerFunctionRejectsOversizedFunction(t *testing.T) {
+	var watBuilder strings.Builder
+	watBuilder.WriteString("(module (func (local")
+	const localCount = 101
+	for i := 0; i < localCount; i++ {
+		watBuilder.WriteString(" i32")
+	}
+	watBuilder.WriteString(")))")
+
+	wasm, err := wabt.Wat2Wasm(watBuilder.String())
+	if err != nil {
+		t.Fatalf("failed to assemble wat: %v", err)
+	}
+
+	_, err = newParserWithConfig(
+		bytes.NewReader(wasm),
+		Config{MaxLocalsPerFunction: 100},
+	).parse()
+	if err == nil || !strings.Contains(err.Error(), "too many locals") {
+		t.Fatalf("expected too-many-locals error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "101") ||
+		!strings.Contains(err.Error(), "100") {
+		t.Fatalf("expected error to mention actual count and configured limit, got %v", err)
+	}
+
+	_, err = newParserWithConfig(
+		bytes.NewReader(wasm),
+		Config{MaxLocalsPerFunction: 200},
+	).parse()
+	if err != nil {
+		t.Fatalf("expected success with raised limit, got %v", err)
 	}
 }

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -31,15 +31,16 @@ func instantiate(
 	if err != nil {
 		return nil, err
 	}
-	module, err := newParser(bytes.NewReader(wasm)).parse()
-	if err != nil {
-		return nil, err
-	}
 
 	cfg := DefaultConfig()
 	if config != nil {
 		cfg = *config
 	}
+	module, err := newParserWithConfig(bytes.NewReader(wasm), cfg).parse()
+	if err != nil {
+		return nil, err
+	}
+
 	vm := newVm(cfg)
 
 	return vm.instantiate(module, imports)
@@ -881,11 +882,9 @@ func TestInstantiateMultipleMemories(t *testing.T) {
 		(data (memory $mem0) (i32.const 0) "hello")
 		(data (memory $mem1) (i32.const 0) "world")
 	)`
-	config := &Config{
-		MaxCallStackDepth:            1000,
-		CallStackPreallocationSize:   1000,
-		ExperimentalMultipleMemories: true,
-	}
+	cfg := DefaultConfig()
+	cfg.ExperimentalMultipleMemories = true
+	config := &cfg
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)
@@ -931,11 +930,9 @@ func TestStoreLoadMultipleMemories(t *testing.T) {
 			i32.load8_u $mem1
 		)
 	)`
-	config := &Config{
-		MaxCallStackDepth:            1000,
-		CallStackPreallocationSize:   1000,
-		ExperimentalMultipleMemories: true,
-	}
+	cfg := DefaultConfig()
+	cfg.ExperimentalMultipleMemories = true
+	config := &cfg
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)
@@ -973,11 +970,9 @@ func TestV128StoreLoadMultipleMemories(t *testing.T) {
 			i32x4.extract_lane 0
 		)
 	)`
-	config := &Config{
-		MaxCallStackDepth:            1000,
-		CallStackPreallocationSize:   1000,
-		ExperimentalMultipleMemories: true,
-	}
+	cfg := DefaultConfig()
+	cfg.ExperimentalMultipleMemories = true
+	config := &cfg
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)
@@ -1012,11 +1007,9 @@ func TestMemoryInitCopyMultipleMemories(t *testing.T) {
 			i32.load $mem2
 		)
 	)`
-	config := &Config{
-		MaxCallStackDepth:            1000,
-		CallStackPreallocationSize:   1000,
-		ExperimentalMultipleMemories: true,
-	}
+	cfg := DefaultConfig()
+	cfg.ExperimentalMultipleMemories = true
+	config := &cfg
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -36,7 +36,7 @@ func instantiate(
 	if config != nil {
 		cfg = *config
 	}
-	module, err := newParserWithConfig(bytes.NewReader(wasm), cfg).parse()
+	module, err := newParser(bytes.NewReader(wasm), cfg).parse()
 	if err != nil {
 		return nil, err
 	}

--- a/epsilon/vm_test.go
+++ b/epsilon/vm_test.go
@@ -882,9 +882,14 @@ func TestInstantiateMultipleMemories(t *testing.T) {
 		(data (memory $mem0) (i32.const 0) "hello")
 		(data (memory $mem1) (i32.const 0) "world")
 	)`
-	cfg := DefaultConfig()
-	cfg.ExperimentalMultipleMemories = true
-	config := &cfg
+	config := &Config{
+		MaxCallStackDepth:            DefaultMaxCallStackDepth,
+		CallStackPreallocationSize:   DefaultCallStackPreallocationSize,
+		MaxTableElements:             DefaultMaxTableElements,
+		MaxMemoryPages:               DefaultMaxMemoryPages,
+		MaxLocalsPerFunction:         DefaultMaxLocalsPerFunction,
+		ExperimentalMultipleMemories: true,
+	}
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)
@@ -930,9 +935,14 @@ func TestStoreLoadMultipleMemories(t *testing.T) {
 			i32.load8_u $mem1
 		)
 	)`
-	cfg := DefaultConfig()
-	cfg.ExperimentalMultipleMemories = true
-	config := &cfg
+	config := &Config{
+		MaxCallStackDepth:            DefaultMaxCallStackDepth,
+		CallStackPreallocationSize:   DefaultCallStackPreallocationSize,
+		MaxTableElements:             DefaultMaxTableElements,
+		MaxMemoryPages:               DefaultMaxMemoryPages,
+		MaxLocalsPerFunction:         DefaultMaxLocalsPerFunction,
+		ExperimentalMultipleMemories: true,
+	}
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)
@@ -970,9 +980,14 @@ func TestV128StoreLoadMultipleMemories(t *testing.T) {
 			i32x4.extract_lane 0
 		)
 	)`
-	cfg := DefaultConfig()
-	cfg.ExperimentalMultipleMemories = true
-	config := &cfg
+	config := &Config{
+		MaxCallStackDepth:            DefaultMaxCallStackDepth,
+		CallStackPreallocationSize:   DefaultCallStackPreallocationSize,
+		MaxTableElements:             DefaultMaxTableElements,
+		MaxMemoryPages:               DefaultMaxMemoryPages,
+		MaxLocalsPerFunction:         DefaultMaxLocalsPerFunction,
+		ExperimentalMultipleMemories: true,
+	}
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)
@@ -1007,9 +1022,14 @@ func TestMemoryInitCopyMultipleMemories(t *testing.T) {
 			i32.load $mem2
 		)
 	)`
-	cfg := DefaultConfig()
-	cfg.ExperimentalMultipleMemories = true
-	config := &cfg
+	config := &Config{
+		MaxCallStackDepth:            DefaultMaxCallStackDepth,
+		CallStackPreallocationSize:   DefaultCallStackPreallocationSize,
+		MaxTableElements:             DefaultMaxTableElements,
+		MaxMemoryPages:               DefaultMaxMemoryPages,
+		MaxLocalsPerFunction:         DefaultMaxLocalsPerFunction,
+		ExperimentalMultipleMemories: true,
+	}
 	moduleInstance, err := instantiate(wat, nil, config)
 	if err != nil {
 		t.Fatalf("failed to create vm: %v", err)

--- a/internal/spec_tests/spec_test_runner.go
+++ b/internal/spec_tests/spec_test_runner.go
@@ -42,13 +42,17 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 	tableLimitMax := uint32(20)
 
 	// Spec tests intentionally declare resources at the WebAssembly spec
-	// maxima (e.g. tables with Max=2^32-1) to exercise edge cases. Raise the
-	// configured ceilings to the spec maxima so the runner reflects what the
-	// engine validator must accept by spec, not what hosts ship by default.
-	config := epsilon.DefaultConfig()
-	config.MaxTableElements = math.MaxUint32
-	config.MaxMemoryPages = uint32(1) << 16
-	runtime := epsilon.NewRuntimeWithConfig(config)
+	// maxima (e.g. tables with Max=2^32-1) to exercise edge cases. Set the
+	// configured ceilings to the spec maxima so the runner reflects what
+	// the engine validator must accept by spec, not what hosts ship by
+	// default.
+	runtime := epsilon.NewRuntimeWithConfig(epsilon.Config{
+		MaxCallStackDepth:          epsilon.DefaultMaxCallStackDepth,
+		CallStackPreallocationSize: epsilon.DefaultCallStackPreallocationSize,
+		MaxTableElements:           math.MaxUint32,
+		MaxMemoryPages:             uint32(1) << 16,
+		MaxLocalsPerFunction:       epsilon.DefaultMaxLocalsPerFunction,
+	})
 	spectestImports := epsilon.NewModuleImports("spectest").
 		AddGlobal("global_i32", runtime.NewGlobalI32(666, false)).
 		AddGlobal("global_i64", runtime.NewGlobalI64(666, false)).

--- a/internal/spec_tests/spec_test_runner.go
+++ b/internal/spec_tests/spec_test_runner.go
@@ -41,7 +41,14 @@ func newSpecRunner(t *testing.T, wasmDict map[string][]byte) *specTestRunner {
 	importMemoryLimitMax := uint32(2)
 	tableLimitMax := uint32(20)
 
-	runtime := epsilon.NewRuntime()
+	// Spec tests intentionally declare resources at the WebAssembly spec
+	// maxima (e.g. tables with Max=2^32-1) to exercise edge cases. Raise the
+	// configured ceilings to the spec maxima so the runner reflects what the
+	// engine validator must accept by spec, not what hosts ship by default.
+	config := epsilon.DefaultConfig()
+	config.MaxTableElements = math.MaxUint32
+	config.MaxMemoryPages = uint32(1) << 16
+	runtime := epsilon.NewRuntimeWithConfig(config)
 	spectestImports := epsilon.NewModuleImports("spectest").
 		AddGlobal("global_i32", runtime.NewGlobalI32(666, false)).
 		AddGlobal("global_i64", runtime.NewGlobalI64(666, false)).


### PR DESCRIPTION
## Summary

A few-byte module could previously declare a multi-GiB table or tens of thousands of locals, forcing the runtime into oversized allocations before instantiation could be refused. This change exposes three ceilings on `Config` so hosts can ratchet them down, with secure defaults that real modules don't trip.

## New Config fields

- `MaxTableElements uint32` — default `10_000_000` (~40 MiB for an int32-backed table; spec max is 2^32-1).
- `MaxMemoryPages uint32` — default `65536` (= 4 GiB, the WebAssembly 32-bit maximum; matches today's behavior).
- `MaxLocalsPerFunction uint32` — default `50_000` (previously `math.MaxInt32`).

## Validator/parser sites that now read them

- `epsilon/validation.go`: the two `validateLimits` calls inside `validateModule` now pass `v.config.MaxTableElements` and `v.config.MaxMemoryPages` instead of `math.MaxUint32` / `uint32(1)<<16`. `validateLimits` itself wraps the violation as `fmt.Errorf("%w: ... exceeds configured limit %d", errInvalidLimits, ...)` so debug output names both the declared count and the configured cap.
- `epsilon/parser.go`: `parseFunction` compares `totalLocalsCount` against `p.config.MaxLocalsPerFunction` and returns the existing `too many locals` error, now formatted with both the actual count and the configured limit.
- A new `newParserWithConfig` constructor threads `Config` into the parser; `runtime.go`'s `InstantiateModuleWithImports` uses it so the parser sees the active runtime config.

## Spec test accommodation

`internal/spec_tests/spec_test_runner.go` now constructs its `Runtime` with `MaxTableElements = math.MaxUint32` and `MaxMemoryPages = 1<<16` — the spec corpus declares tables with `Max=2^32-1` to exercise edge cases, so the runner needs to permit what the WebAssembly spec maxima permit, independent of what hosts ship.

## Test plan

- [x] `go test ./...` passes (including new focused tests for each limit in `epsilon/validation_test.go`)
- [x] `go test ./internal/spec_tests/...` passes
- [x] `go test -bench=. -benchmem -count=5 ./internal/benchmarks/...` shows no regression; checks live at validate/parse time, not in the VM hot path.

## Benchstat (delta vs. main, sec/op)

```
                         │ before │           after            │
FactorialRecursive       685.9n   684.1n       ~ (p=0.548 n=5)
FibonacciRecursive       12.16m   12.39m  +1.95% (p=0.008 n=5)
MatrixMultiplication      1.829    1.860  +1.71% (p=0.008 n=5)
SortingQuickSort         1.200m   1.235m  +2.94% (p=0.016 n=5)
geomean                  445.5µ   450.1µ  +1.03%
```

Allocations and bytes per op are identical across every benchmark; the wall-time deltas are noise-level (geomean +1.03% on a single-machine n=5 run, no code added to the VM instruction loop).

## Behavior change

Modules declaring a table with more than 10,000,000 elements, or a function declaring more than 50,000 locals, that previously parsed will now be rejected by default. Hosts that need the old behavior can opt back in via `Config.MaxTableElements` / `Config.MaxLocalsPerFunction`. The `MaxMemoryPages` default matches the existing hard-coded cap (the WebAssembly 32-bit memory maximum), so it is not a regression.