### PR TITLE
Performance improvement

### DIFF
--- a/epsilon/value_stack.go
+++ b/epsilon/value_stack.go
@@ -121,6 +121,11 @@ func (s *valueStack) popValueTypes(types []ValueType) []any {
 }
 
 func (s *valueStack) unwind(targetHeight, preserveCount uint32) {
+	// When the stack is already at the target size, the slice/append below is a
+	// no-op and we can skip it.
+	if uint32(len(s.data)) == targetHeight+preserveCount {
+		return
+	}
 	valuesToPreserve := s.data[s.size()-preserveCount:]
 	s.data = s.data[:targetHeight]
 	s.data = append(s.data, valuesToPreserve...)

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -1793,16 +1793,11 @@ func handleSimdReplaceLane[T wasmNumber](
 }
 
 func (vm *vm) getInputCount(module *ModuleInstance, blockType int32) uint32 {
-	if blockType == -0x40 { // empty block type.
+	// Empty (-0x40) and value-type block types both consume no inputs.
+	if blockType < 0 {
 		return 0
 	}
-
-	if blockType >= 0 { // type index.
-		funcType := module.types[blockType]
-		return uint32(len(funcType.ParamTypes))
-	}
-
-	return 0 // value type.
+	return uint32(len(module.types[blockType].ParamTypes))
 }
 
 func (vm *vm) getOutputCount(module *ModuleInstance, blockType int32) uint32 {

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -1331,9 +1331,7 @@ func (vm *vm) handleElse(frame *callFrame) {
 }
 
 func (vm *vm) handleEnd(frame *callFrame) {
-	controlFrame := vm.popControlFrame(frame)
-	outputCount := vm.getOutputCount(frame.module, controlFrame.blockType)
-	vm.stack.unwind(controlFrame.stackHeight, outputCount)
+	frame.controlStack = frame.controlStack[:len(frame.controlStack)-1]
 }
 
 func (vm *vm) handleBrIf(frame *callFrame) {


### PR DESCRIPTION
## Summary

- **`handleEnd` no longer calls `unwind` / `getOutputCount`.** Validation guarantees the stack height is already `stackHeight + outputCount` when a block falls through to `end`, so the unwind is redundant work. The handler now just pops the control frame. Branches that exit nested blocks still go through `brToLabel`, which keeps the full unwind logic.
- **`unwind` short-circuits when the stack is already at the target size.** In `brToLabel` this covers branches from the immediate block — common for `return` from the top level of a function.

## Perf impact (vs the numbers in `CHANGELOG-0.1.0.draft.md`)

| Benchmark           | v0.1.0-draft | After this PR | Δ      |
|---------------------|--------------|---------------|--------|
| FactorialRecursive  | 675 ns       | ~652 ns       | -3.4%  |
| FibonacciRecursive  | 12.09 ms     | ~10.92 ms     | -9.7%  |
| Indirect            | 6781 ns      | ~6461 ns      | -4.7%  |