### PR TITLE
Harden and expand WebAssembly benchmarks suite

### DIFF
--- a/internal/benchmarks/benchmark_test.go
+++ b/internal/benchmarks/benchmark_test.go
@@ -16,6 +16,7 @@
 package benchmarks
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
@@ -29,7 +30,7 @@ func BenchmarkFactorialRecursive(b *testing.B) {
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fac_recursive", int64(25))
+		_, err := instance.Invoke("fac_recursive", int32(1000), int64(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -43,7 +44,7 @@ func BenchmarkFactorialIterative(b *testing.B) {
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fac_iterative", int64(25))
+		_, err := instance.Invoke("fac_iterative", int32(10000), int64(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -57,7 +58,7 @@ func BenchmarkFibonacciRecursive(b *testing.B) {
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fib_recursive", int32(25))
+		_, err := instance.Invoke("fib_recursive", int32(1), int32(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -71,7 +72,7 @@ func BenchmarkFibonacciIterative(b *testing.B) {
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("fib_iterative", int32(25))
+		_, err := instance.Invoke("fib_iterative", int32(10000), int32(25))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -85,7 +86,7 @@ func BenchmarkIndirect(b *testing.B) {
 	}
 
 	for b.Loop() {
-		_, err := instance.Invoke("run_indirect_calls", int32(100))
+		_, err := instance.Invoke("run_indirect_calls", int32(10000))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}
@@ -184,6 +185,69 @@ func BenchmarkSortingQuickSort(b *testing.B) {
 
 	for b.Loop() {
 		_, err := instance.Invoke("quick_sort")
+		if err != nil {
+			b.Fatalf("failed to execute benchmark: %v", err)
+		}
+	}
+}
+
+func BenchmarkHostCall(b *testing.B) {
+	wasm, err := os.ReadFile("wasm/host_call.wasm")
+	if err != nil {
+		b.Fatalf("failed to read wasm: %v", err)
+	}
+	imports := epsilon.NewModuleImports("env").
+		AddHostFunc("noop", func(_ *epsilon.ModuleInstance, args ...any) []any {
+			return []any{args[0]}
+		})
+	instance, err := epsilon.NewRuntime().
+		InstantiateModuleWithImports(bytes.NewReader(wasm), imports)
+	if err != nil {
+		b.Fatalf("failed to instantiate: %v", err)
+	}
+
+	for b.Loop() {
+		_, err := instance.Invoke("run_host_calls", int32(10000))
+		if err != nil {
+			b.Fatalf("failed to execute benchmark: %v", err)
+		}
+	}
+}
+
+func BenchmarkInstantiateSmall(b *testing.B) {
+	wasm, err := os.ReadFile("wasm/factorial.wasm")
+	if err != nil {
+		b.Fatalf("failed to read wasm: %v", err)
+	}
+	for b.Loop() {
+		_, err := epsilon.NewRuntime().InstantiateModuleFromBytes(wasm)
+		if err != nil {
+			b.Fatalf("failed to instantiate: %v", err)
+		}
+	}
+}
+
+func BenchmarkInstantiateLarge(b *testing.B) {
+	wasm, err := os.ReadFile("wasm/sorting.wasm")
+	if err != nil {
+		b.Fatalf("failed to read wasm: %v", err)
+	}
+	for b.Loop() {
+		_, err := epsilon.NewRuntime().InstantiateModuleFromBytes(wasm)
+		if err != nil {
+			b.Fatalf("failed to instantiate: %v", err)
+		}
+	}
+}
+
+func BenchmarkSHA256(b *testing.B) {
+	instance, err := instantiate("wasm/sha256.wasm")
+	if err != nil {
+		b.Fatalf("failed to initialize test: %v", err)
+	}
+
+	for b.Loop() {
+		_, err := instance.Invoke("run_sha256", int32(64))
 		if err != nil {
 			b.Fatalf("failed to execute benchmark: %v", err)
 		}

--- a/internal/benchmarks/src/factorial.c
+++ b/internal/benchmarks/src/factorial.c
@@ -16,19 +16,37 @@
 
 #include <stdint.h>
 
-__attribute__((export_name("fac_recursive")))
-int64_t fac_recursive(int64_t n) {
+__attribute__((noinline))
+static int64_t fac_recursive_impl(int64_t n) {
   if (n == 0) {
     return 1;
   }
-  return n * fac_recursive(n - 1);
+  // `volatile` blocks LLVM's scalar-evolution pass from rewriting the
+  // accumulator into an iterative loop, so the recursion survives -O3.
+  volatile int64_t sub = fac_recursive_impl(n - 1);
+  return n * sub;
+}
+
+// `n` is passed in (rather than hardcoded) so LLVM can't fold the inner
+// loop into a closed-form expression.
+__attribute__((export_name("fac_recursive")))
+int64_t fac_recursive(int32_t iterations, int64_t n) {
+  int64_t total = 0;
+  for (int32_t i = 0; i < iterations; i++) {
+    total += fac_recursive_impl(n);
+  }
+  return total;
 }
 
 __attribute__((export_name("fac_iterative")))
-int64_t fac_iterative(int64_t n) {
-  int64_t fac = 1;
-  for (int i = 2; i <=n; i++) {
-    fac *= i;
-  } 
-  return fac;
+int64_t fac_iterative(int32_t iterations, int64_t n) {
+  int64_t total = 0;
+  for (int32_t iter = 0; iter < iterations; iter++) {
+    int64_t fac = 1;
+    for (int64_t i = 2; i <= n; i++) {
+      fac *= i;
+    }
+    total += fac;
+  }
+  return total;
 }

--- a/internal/benchmarks/src/fibonacci.c
+++ b/internal/benchmarks/src/fibonacci.c
@@ -14,35 +14,46 @@
  * limitations under the License.
  */
 
-__attribute__((export_name("fib_recursive")))
-int fib_recursive(int n) {
+#include <stdint.h>
+
+__attribute__((noinline))
+static int fib_recursive_impl(int n) {
   if (n == 0) {
     return 0;
   }
-
   if (n == 1) {
     return 1;
   }
+  // `volatile` prevents LLVM from rewriting one recursive call into a loop,
+  // so both branches of the tree recursion survive -O3.
+  volatile int a = fib_recursive_impl(n - 1);
+  volatile int b = fib_recursive_impl(n - 2);
+  return a + b;
+}
 
-  return fib_recursive(n - 1) + fib_recursive(n - 2);
+// `n` is passed in (rather than hardcoded) so LLVM can't fold the inner
+// loop into a closed-form expression.
+__attribute__((export_name("fib_recursive")))
+int fib_recursive(int32_t iterations, int32_t n) {
+  int total = 0;
+  for (int32_t i = 0; i < iterations; i++) {
+    total += fib_recursive_impl(n);
+  }
+  return total;
 }
 
 __attribute__((export_name("fib_iterative")))
-int fib_iterative(int n) {
-  if (n == 0) {
-    return 0;
+int fib_iterative(int32_t iterations, int32_t n) {
+  int total = 0;
+  for (int32_t iter = 0; iter < iterations; iter++) {
+    int a = 0;
+    int b = 1;
+    for (int32_t i = 2; i <= n; i++) {
+      int next = a + b;
+      a = b;
+      b = next;
+    }
+    total += b;
   }
-
-  if (n == 1) {
-    return 1;
-  }
-
-  int a = 0;
-  int b = 1;
-  for (int i = 2; i <= n; i++) {
-    int next = a + b;
-    a = b;
-    b = next;
-  }
-  return b;
+  return total;
 }

--- a/internal/benchmarks/src/host_call.c
+++ b/internal/benchmarks/src/host_call.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+
+__attribute__((import_module("env"), import_name("noop")))
+extern int32_t host_noop(int32_t x);
+
+__attribute__((export_name("run_host_calls")))
+int32_t run_host_calls(int32_t iterations) {
+  int32_t result = 0;
+  for (int32_t i = 0; i < iterations; i++) {
+    result = host_noop(result + i);
+  }
+  return result;
+}

--- a/internal/benchmarks/src/matrix_multiplication.c
+++ b/internal/benchmarks/src/matrix_multiplication.c
@@ -26,6 +26,7 @@ float matrix_a[DIM][DIM];
 float matrix_b[DIM][DIM];
 float result_matrix[DIM][DIM];
 
+__attribute__((noinline))
 void multiply() {
   for (int i = 0; i < DIM; i++) {
     for (int j = 0; j < DIM; j++) {

--- a/internal/benchmarks/src/sha256.c
+++ b/internal/benchmarks/src/sha256.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Self-contained SHA-256 (FIPS 180-4). Exercises i32 shift/rotate/xor/and
+ * at scale in a realistic, well-known workload. No libc dependencies.
+ */
+
+#include <stdint.h>
+
+#define BUFFER_SIZE 65536
+#define ROTR(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
+
+static const uint32_t K[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+static uint8_t buffer[BUFFER_SIZE];
+
+static void process_block(uint32_t state[8], const uint8_t block[64]) {
+  uint32_t w[64];
+  for (int i = 0; i < 16; i++) {
+    w[i] = ((uint32_t)block[i * 4] << 24) |
+           ((uint32_t)block[i * 4 + 1] << 16) |
+           ((uint32_t)block[i * 4 + 2] << 8) |
+           ((uint32_t)block[i * 4 + 3]);
+  }
+  for (int i = 16; i < 64; i++) {
+    uint32_t s0 = ROTR(w[i - 15], 7) ^ ROTR(w[i - 15], 18) ^ (w[i - 15] >> 3);
+    uint32_t s1 = ROTR(w[i - 2], 17) ^ ROTR(w[i - 2], 19) ^ (w[i - 2] >> 10);
+    w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+  }
+
+  uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+  uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+  for (int i = 0; i < 64; i++) {
+    uint32_t S1 = ROTR(e, 6) ^ ROTR(e, 11) ^ ROTR(e, 25);
+    uint32_t ch = (e & f) ^ (~e & g);
+    uint32_t t1 = h + S1 + ch + K[i] + w[i];
+    uint32_t S0 = ROTR(a, 2) ^ ROTR(a, 13) ^ ROTR(a, 22);
+    uint32_t mj = (a & b) ^ (a & c) ^ (b & c);
+    uint32_t t2 = S0 + mj;
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+
+  state[0] += a;
+  state[1] += b;
+  state[2] += c;
+  state[3] += d;
+  state[4] += e;
+  state[5] += f;
+  state[6] += g;
+  state[7] += h;
+}
+
+/* Hashes `buffer` (BUFFER_SIZE bytes, which is an exact multiple of 64) and
+ * writes the digest into `out`. Skips length-padding for simplicity — the
+ * benchmark just wants to exercise the compression function at scale.
+ */
+static void sha256(uint8_t out[32]) {
+  uint32_t state[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                       0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  for (int i = 0; i < BUFFER_SIZE; i += 64) {
+    process_block(state, &buffer[i]);
+  }
+  for (int i = 0; i < 8; i++) {
+    out[i * 4] = (uint8_t)(state[i] >> 24);
+    out[i * 4 + 1] = (uint8_t)(state[i] >> 16);
+    out[i * 4 + 2] = (uint8_t)(state[i] >> 8);
+    out[i * 4 + 3] = (uint8_t)state[i];
+  }
+}
+
+__attribute__((export_name("run_sha256")))
+uint32_t run_sha256(int32_t iterations) {
+  for (int i = 0; i < BUFFER_SIZE; i++) {
+    buffer[i] = (uint8_t)(i * 31 % 251);
+  }
+
+  uint8_t digest[32];
+  uint32_t accum = 0;
+  for (int32_t iter = 0; iter < iterations; iter++) {
+    sha256(digest);
+    accum += digest[0];
+    buffer[0] = digest[0];
+  }
+  return accum;
+}

--- a/internal/benchmarks/src/sorting.c
+++ b/internal/benchmarks/src/sorting.c
@@ -192,6 +192,7 @@ int partition(int *array, int left, int right) {
   return i + 1;
 }
 
+__attribute__((noinline, disable_tail_calls))
 void quick_sort_internal(int *array, int left, int right) {
   if (left >= right) {
     return;


### PR DESCRIPTION
This PR hardens and expands Epsilon's WebAssembly benchmark suite. It improves benchmark stability and prevents LLVM optimizations from distorting VM performance measurements under `-O3`.

### Key Changes
* **Recursion & Inlining Protections (`factorial.c`, `fibonacci.c`, `sorting.c`)**:
  * Added `volatile` variables, `noinline`, and `disable_tail_calls` compiler attributes to ensure recursive calls are strictly maintained and the VM's call stack is properly exercised.
* **Elimination of Invocation Round-trip Bias**:
  * Shifted iteration loops into the WebAssembly binaries (e.g., `fac_recursive(int32_t iterations, int64_t n)`). This ensures the benchmarks measure raw WebAssembly execution rather than Go-to-WASM invocation round-trips.
* **Three New Benchmark Workloads**:
  1. **SHA-256 Hashing (`sha256.c` & `BenchmarkSHA256`)**: Exercises dense integer calculations, shifts, and rotations at scale.
  2. **Host Call round-trip (`host_call.c` & `BenchmarkHostCall`)**: Measures imported host function call overhead.
  3. **Module Instantiation (`BenchmarkInstantiate*`)**: Measures parsing, validation, and instantiation latency for both small and large modules.

### Verification Results
All tests and benchmarks run successfully without regressions.
* `make build-wasm`: Successfully compiled the new benchmark WASM binaries.
* `make bench`: All benchmarks run stably and complete flawlessly.
* `make test`: All unit/spec tests pass.
* `make test-wasi`: All WASI preview 1 tests pass.