### PR TITLE
Reduce parser and VM call-path allocations

### DIFF
--- a/epsilon/config.go
+++ b/epsilon/config.go
@@ -29,11 +29,9 @@ type Config struct {
 	// Default: DefaultMaxCallStackDepth.
 	MaxCallStackDepth int
 
-	// CallStackPreallocationSize is the number of call frames the VM preallocates
-	// buffers for. The control-stack cache reserves a fixed slot per frame up to
-	// this depth; deeper frames use the heap. The locals cache is a shared pool
-	// of this many frames' worth of locals; frames draw from it on demand and
-	// fall back to the heap when it is exhausted.
+	// CallStackPreallocationSize is the number of call frames the VM reserves
+	// control-stack and locals buffers for up front. Calls within this depth
+	// avoid per-call heap allocation; deeper calls fall back to the heap.
 	// Default: DefaultCallStackPreallocationSize.
 	CallStackPreallocationSize int
 

--- a/epsilon/config.go
+++ b/epsilon/config.go
@@ -29,9 +29,11 @@ type Config struct {
 	// Default: DefaultMaxCallStackDepth.
 	MaxCallStackDepth int
 
-	// CallStackPreallocationSize controls how many call frames to preallocate.
-	// Caches (controlStackCache, localsCache) are sized to this value.
-	// Beyond this depth, allocations fall back to heap.
+	// CallStackPreallocationSize is the number of call frames the VM preallocates
+	// buffers for. The control-stack cache reserves a fixed slot per frame up to
+	// this depth; deeper frames use the heap. The locals cache is a shared pool
+	// of this many frames' worth of locals; frames draw from it on demand and
+	// fall back to the heap when it is exhausted.
 	// Default: DefaultCallStackPreallocationSize.
 	CallStackPreallocationSize int
 

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -52,12 +52,12 @@ const (
 	sixthBitMask         = uint64(1 << 6)
 )
 
-// initialVectorCapacity caps the up-front allocation parseVector and similar
+// maxInitialCapacity caps the up-front allocation parseVector and similar
 // callers perform from an attacker-controlled count. Real modules rarely
 // exceed a few thousand items per vector, so this is the common-case exact
 // size; pathological counts grow via append+EOF instead of OOMing on a
 // pre-allocation.
-const initialVectorCapacity = 4096
+const maxInitialCapacity = 4096
 
 // sectionId represents the different sections of a WebAssembly module.
 // See https://webassembly.github.io/spec/core/binary/modules.html#sections
@@ -84,8 +84,7 @@ type localEntry struct {
 	typ   ValueType
 }
 
-// wasmReader is the combined reader interface the parser needs: single-byte
-// reads for LEB128 decoding plus bulk reads for section payloads.
+// wasmReader is an interface that combines io.Reader and io.ByteReader.
 type wasmReader interface {
 	io.Reader
 	io.ByteReader
@@ -93,7 +92,7 @@ type wasmReader interface {
 
 // limitedByteReader caps reads at rem bytes from an underlying wasmReader. It
 // is equivalent to wrapping an io.LimitReader in a bufio.Reader to regain
-// ByteReader, but reads from the source directly and so needs no buffer.
+// ByteReader, but reads from the source directly and so allocates no buffer.
 type limitedByteReader struct {
 	r   wasmReader
 	rem int64
@@ -353,7 +352,7 @@ func (p *parser) parseFunction() (function, error) {
 		)
 	}
 
-	locals := make([]ValueType, 0, min(totalLocalsCount, initialVectorCapacity))
+	locals := make([]ValueType, 0, min(totalLocalsCount, maxInitialCapacity))
 	for _, entry := range localEntries {
 		for i := uint64(0); i < entry.count; i++ {
 			locals = append(locals, entry.typ)
@@ -813,7 +812,7 @@ func parseVector[T any](parser *parser, parse func() (T, error)) ([]T, error) {
 	if err != nil {
 		return nil, err
 	}
-	items := make([]T, 0, min(count, initialVectorCapacity))
+	items := make([]T, 0, min(count, maxInitialCapacity))
 	for i := uint32(0); i < count; i++ {
 		parsed, err := parse()
 		if err != nil {
@@ -853,11 +852,11 @@ func (p *parser) parseUtf8String() (string, error) {
 }
 
 // readN reads exactly length bytes from the reader. The initial buffer
-// capacity is capped at initialVectorCapacity so an attacker-controlled
+// capacity is capped at maxInitialCapacity so an attacker-controlled
 // length cannot force a huge up-front allocation; the buffer grows as needed
 // and a short read surfaces as an error.
 func (p *parser) readN(length uint64) ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0, min(length, initialVectorCapacity)))
+	buf := bytes.NewBuffer(make([]byte, 0, min(length, maxInitialCapacity)))
 	if _, err := io.CopyN(buf, p.reader, int64(length)); err != nil {
 		return nil, err
 	}
@@ -918,24 +917,26 @@ type bytecodeResult struct {
 	jumpElseCache map[uint32]uint32
 }
 
-// readCode reads a sequence of instructions into the flat uint64 bytecode
-// slice. sizeHint is the body's byte length when known (0 otherwise), used only
-// to size the bytecode buffer up front and avoid repeated slice growth.
+// readCode decodes a sequence of WASM instructions into the flat uint64
+// bytecode the VM executes, and returns it with the jump caches that map each
+// block/if to its branch targets.
 //
-// It is an estimate, not an exact count: bytecode holds one uint64 per decoded
-// word, so a multi-byte LEB immediate (e.g. a wide i32.const) collapses several
-// bytes into one word, while a memory argument expands a couple of bytes into
-// several words. In practice most instructions map a byte to roughly a word, so
-// the hint is close; a miss in either direction just costs one more append.
+// Decoding stops at the first instruction for which isEnd returns true; a nil
+// isEnd decodes until the reader reaches EOF, which a function body's bounded
+// reader hits at the end of the body. A sequence that does not end with an end
+// opcode is rejected with errMissingEndOpcode.
+//
+// sizeHint only seeds the bytecode buffer capacity to avoid regrowth: it is the
+// body's declared byte length, or 0 if unknown, and need not be accurate.
 func (p *parser) readCode(
 	sizeHint uint32,
 	isEnd func([]uint64) bool,
 ) (bytecodeResult, error) {
 	// sizeHint is attacker-controlled (the function body's declared size), so cap
-	// the initial capacity at initialVectorCapacity. The buffer still grows via
+	// the initial capacity at maxInitialCapacity. The buffer still grows via
 	// append as real bytes are decoded; a bogus huge size cannot force a large
 	// up-front allocation.
-	bytecode := make([]uint64, 0, min(sizeHint, initialVectorCapacity))
+	bytecode := make([]uint64, 0, min(sizeHint, maxInitialCapacity))
 	// The jump caches are allocated lazily: a function with no control flow
 	// never branches, so it needs neither map.
 	var jumpCache map[uint32]uint32
@@ -1236,7 +1237,7 @@ func (p *parser) readImmediateVector() ([]uint64, error) {
 		return nil, err
 	}
 
-	immediates := make([]uint64, 0, min(size, initialVectorCapacity))
+	immediates := make([]uint64, 0, min(size, maxInitialCapacity))
 	for range size {
 		val, err := p.readUint32()
 		if err != nil {

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -931,7 +931,11 @@ func (p *parser) readCode(
 	sizeHint uint32,
 	isEnd func([]uint64) bool,
 ) (bytecodeResult, error) {
-	bytecode := make([]uint64, 0, sizeHint)
+	// sizeHint is attacker-controlled (the function body's declared size), so cap
+	// the initial capacity at initialVectorCapacity. The buffer still grows via
+	// append as real bytes are decoded; a bogus huge size cannot force a large
+	// up-front allocation.
+	bytecode := make([]uint64, 0, min(sizeHint, initialVectorCapacity))
 	// The jump caches are allocated lazily: a function with no control flow
 	// never branches, so it needs neither map.
 	var jumpCache map[uint32]uint32

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -360,7 +360,7 @@ func (p *parser) parseFunction() (function, error) {
 		}
 	}
 
-	result, err := p.readCode(nil)
+	result, err := p.readCode(size, nil)
 	if err != nil {
 		return function{}, err
 	}
@@ -776,7 +776,7 @@ func (p *parser) parseElementSegment() (elementSegment, error) {
 }
 
 func (p *parser) parseExpression() ([]uint64, error) {
-	result, err := p.readCode(func(instruction []uint64) bool {
+	result, err := p.readCode(0, func(instruction []uint64) bool {
 		return opcode(instruction[0]) == end
 	})
 	if err != nil {
@@ -918,10 +918,25 @@ type bytecodeResult struct {
 	jumpElseCache map[uint32]uint32
 }
 
-func (p *parser) readCode(isEnd func([]uint64) bool) (bytecodeResult, error) {
-	bytecode := []uint64{}
-	jumpCache := map[uint32]uint32{}
-	jumpElseCache := map[uint32]uint32{}
+// readCode reads a sequence of instructions into the flat uint64 bytecode
+// slice. sizeHint is the body's byte length when known (0 otherwise), used only
+// to size the bytecode buffer up front and avoid repeated slice growth.
+//
+// It is an estimate, not an exact count: bytecode holds one uint64 per decoded
+// word, so a multi-byte LEB immediate (e.g. a wide i32.const) collapses several
+// bytes into one word, while a memory argument expands a couple of bytes into
+// several words. In practice most instructions map a byte to roughly a word, so
+// the hint is close; a miss in either direction just costs one more append.
+func (p *parser) readCode(
+	sizeHint uint32,
+	isEnd func([]uint64) bool,
+) (bytecodeResult, error) {
+	bytecode := make([]uint64, 0, sizeHint)
+	// The jump caches are allocated lazily: a function with no control flow
+	// never branches, so it needs neither map.
+	var jumpCache map[uint32]uint32
+	var jumpElseCache map[uint32]uint32
+
 	controlStack := []controlEntry{}
 	var lastOp opcode
 
@@ -940,6 +955,10 @@ func (p *parser) readCode(isEnd func([]uint64) bool) (bytecodeResult, error) {
 
 		switch opcodeVal {
 		case block, loop, ifOp:
+			if jumpCache == nil {
+				jumpCache = map[uint32]uint32{}
+				jumpElseCache = map[uint32]uint32{}
+			}
 			immediate, err := p.readBlockType()
 			if err != nil {
 				return bytecodeResult{}, err

--- a/epsilon/parser.go
+++ b/epsilon/parser.go
@@ -84,14 +84,58 @@ type localEntry struct {
 	typ   ValueType
 }
 
+// wasmReader is the combined reader interface the parser needs: single-byte
+// reads for LEB128 decoding plus bulk reads for section payloads.
+type wasmReader interface {
+	io.Reader
+	io.ByteReader
+}
+
+// limitedByteReader caps reads at rem bytes from an underlying wasmReader. It
+// is equivalent to wrapping an io.LimitReader in a bufio.Reader to regain
+// ByteReader, but reads from the source directly and so needs no buffer.
+type limitedByteReader struct {
+	r   wasmReader
+	rem int64
+}
+
+func (l *limitedByteReader) Read(p []byte) (int, error) {
+	if l.rem <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > l.rem {
+		p = p[:l.rem]
+	}
+	n, err := l.r.Read(p)
+	l.rem -= int64(n)
+	return n, err
+}
+
+func (l *limitedByteReader) ReadByte() (byte, error) {
+	if l.rem <= 0 {
+		return 0, io.EOF
+	}
+	b, err := l.r.ReadByte()
+	if err == nil {
+		l.rem--
+	}
+	return b, err
+}
+
 // parser is a parser for WASM modules.
 type parser struct {
-	reader *bufio.Reader
+	reader wasmReader
 	config Config
 }
 
 func newParser(reader io.Reader, config Config) *parser {
-	return &parser{reader: bufio.NewReader(reader), config: config}
+	var wr wasmReader
+	if r, ok := reader.(wasmReader); ok {
+		wr = r
+	} else {
+		wr = bufio.NewReader(reader)
+	}
+	return &parser{reader: wr, config: config}
 }
 
 // parse takes a byte slice and returns a Module.
@@ -267,13 +311,11 @@ func (p *parser) parseCustomSection(payloadLen uint32) error {
 		return errIntegerTooLarge
 	}
 
-	nameBytes := bytes.NewBuffer(
-		make([]byte, 0, min(nameLength, initialVectorCapacity)),
-	)
-	if _, err := io.CopyN(nameBytes, p.reader, int64(nameLength)); err != nil {
+	nameBytes, err := p.readN(nameLength)
+	if err != nil {
 		return err
 	}
-	if !utf8.Valid(nameBytes.Bytes()) {
+	if !utf8.Valid(nameBytes) {
 		return errInvalidUTF8
 	}
 
@@ -292,9 +334,8 @@ func (p *parser) parseFunction() (function, error) {
 	originalReader := p.reader
 	defer func() { p.reader = originalReader }()
 
-	// We create a new reader to limit how many bytes we can read to `size`.
-	limitedReader := io.LimitReader(originalReader, int64(size))
-	p.reader = bufio.NewReader(limitedReader)
+	// Limit reads to this function's body of `size` bytes.
+	p.reader = &limitedByteReader{r: originalReader, rem: int64(size)}
 
 	localEntries, err := parseVector(p, p.parseLocalVariables)
 	if err != nil {
@@ -324,9 +365,9 @@ func (p *parser) parseFunction() (function, error) {
 		return function{}, err
 	}
 
-	// Drain any bytes the bufio.Reader pre-fetched but the parser didn't consume.
-	// Without this, the outer reader resumes at the wrong offset when bufio has
-	// buffered past what was actually parsed (e.g., early end opcode).
+	// Discard any bytes of the function body the parser didn't consume (e.g.
+	// trailing bytes after an early end opcode) so the underlying reader is
+	// positioned at the start of the next function.
 	if _, err := io.Copy(io.Discard, p.reader); err != nil {
 		return function{}, err
 	}
@@ -804,11 +845,23 @@ func (p *parser) parseUtf8String() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	buf := bytes.NewBuffer(make([]byte, 0, min(length, initialVectorCapacity)))
-	if _, err := io.CopyN(buf, p.reader, int64(length)); err != nil {
+	stringBytes, err := p.readN(uint64(length))
+	if err != nil {
 		return "", fmt.Errorf("failed to read string bytes: %w", err)
 	}
-	return buf.String(), nil
+	return string(stringBytes), nil
+}
+
+// readN reads exactly length bytes from the reader. The initial buffer
+// capacity is capped at initialVectorCapacity so an attacker-controlled
+// length cannot force a huge up-front allocation; the buffer grows as needed
+// and a short read surfaces as an error.
+func (p *parser) readN(length uint64) ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, min(length, initialVectorCapacity)))
+	if _, err := io.CopyN(buf, p.reader, int64(length)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func uint64SliceToInt32(slice []uint64) []int32 {

--- a/epsilon/parser_test.go
+++ b/epsilon/parser_test.go
@@ -66,8 +66,8 @@ func TestParseExportedFunction(t *testing.T) {
 					uint64(i32Add),
 					uint64(end),
 				},
-				jumpCache:     map[uint32]uint32{},
-				jumpElseCache: map[uint32]uint32{},
+				jumpCache:     nil,
+				jumpElseCache: nil,
 			},
 		},
 		exports: []export{

--- a/epsilon/validation.go
+++ b/epsilon/validation.go
@@ -303,7 +303,9 @@ func (v *validator) validateDataSegment(data *dataSegment) error {
 
 func (v *validator) validateFunction(function *function) error {
 	functionType := v.typeDefs[function.typeIndex]
-	v.locals = append(functionType.ParamTypes, function.locals...)
+	v.locals = v.locals[:0]
+	v.locals = append(v.locals, functionType.ParamTypes...)
+	v.locals = append(v.locals, function.locals...)
 	v.returnType = functionType.ResultTypes
 	v.valueStack = v.valueStack[:0]
 	v.controlStack = v.controlStack[:0]

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -93,8 +93,13 @@ type vm struct {
 	callStack         []callFrame
 	controlStackCache []controlFrame
 	localsCache       []value
-	config            Config
-	fuel              uint64
+	// localsTop is the bump-allocation cursor into localsCache: each wasm call
+	// carves its locals starting here, advances the cursor, and rewinds it when
+	// the call returns. This lets a frame with many locals use the shared cache
+	// rather than allocating them on the heap.
+	localsTop int
+	config    Config
+	fuel      uint64
 }
 
 func newVm(config Config) *vm {
@@ -279,25 +284,32 @@ func (vm *vm) invokeWasmFunction(function *wasmFunction) error {
 	}
 
 	callDepth := len(vm.callStack)
-	withinPreallocation := callDepth < vm.config.CallStackPreallocationSize
+	// The control stack uses a fixed per-depth slot in controlStackCache, which
+	// only covers call depths within the preallocated range; deeper frames put
+	// their control stack on the heap.
+	useControlStackCache := callDepth < vm.config.CallStackPreallocationSize
 
 	numParams := len(function.functionType.ParamTypes)
 	numLocals := numParams + len(function.code.locals)
+
+	// Bump-allocate locals from the cache: take numLocals slots at localsTop and
+	// advance it (rewound after the call returns). Nested calls bump further, so
+	// frames never overlap. Only an exhausted cache falls back to the heap.
+	localsMark := vm.localsTop
 	var locals []value
-	if withinPreallocation && numLocals <= localsCacheSlotSize {
-		blockDepth := callDepth * localsCacheSlotSize
-		max := blockDepth + localsCacheSlotSize
-		locals = vm.localsCache[blockDepth : blockDepth+numLocals : max]
-		// Clear non-parameter locals to their zero values. WASM allows reading
-		// uninitialized locals, so we must zero them to avoid reusing stale values
-		// from previous invocations. Parameters are overwritten below.
+	if end := localsMark + numLocals; end <= len(vm.localsCache) {
+		locals = vm.localsCache[localsMark:end:end]
+		vm.localsTop = end
+		// Cache slots may hold stale values from earlier calls, and WASM allows
+		// reading uninitialized locals, so zero the non-parameter locals. The
+		// parameter slots are filled from the operand stack afterward.
 		if function.code.defaultLocals != nil {
 			copy(locals[numParams:], function.code.defaultLocals)
 		} else {
 			clear(locals[numParams:])
 		}
 	} else {
-		// Beyond preallocation or too many locals: heap allocate.
+		// Cache exhausted: heap allocate (make already zeroes the locals).
 		locals = make([]value, numLocals)
 		if function.code.defaultLocals != nil {
 			copy(locals[numParams:], function.code.defaultLocals)
@@ -310,7 +322,7 @@ func (vm *vm) invokeWasmFunction(function *wasmFunction) error {
 	vm.stack.data = vm.stack.data[:newLen]
 
 	var controlStack []controlFrame
-	if withinPreallocation {
+	if useControlStackCache {
 		// Use part of the cache for the control stack to avoid allocations.
 		blockDepth := callDepth * controlStackCacheSlotSize
 		// Slice cap to prevent appending into the next slot.
@@ -335,10 +347,16 @@ func (vm *vm) invokeWasmFunction(function *wasmFunction) error {
 	// To avoid the performance penalty of checking the fuel limit on every
 	// instruction when fuel is disabled, we provide two separate loop
 	// implementations.
+	var err error
 	if vm.config.EnableFuel {
-		return vm.runLoopWithFuel()
+		err = vm.runLoopWithFuel()
+	} else {
+		err = vm.runLoop()
 	}
-	return vm.runLoop()
+	// The run loop pops this frame before returning, so its locals slots are free
+	// to reuse. Rewinding the cursor here is a no-op for the heap case.
+	vm.localsTop = localsMark
+	return err
 }
 
 func (vm *vm) runLoop() error {

--- a/epsilon/vm.go
+++ b/epsilon/vm.go
@@ -284,17 +284,15 @@ func (vm *vm) invokeWasmFunction(function *wasmFunction) error {
 	}
 
 	callDepth := len(vm.callStack)
-	// The control stack uses a fixed per-depth slot in controlStackCache, which
-	// only covers call depths within the preallocated range; deeper frames put
-	// their control stack on the heap.
+	// Unlike locals, the control stack uses a fixed per-depth slot; only depths
+	// within the preallocated range are cached, and deeper frames use the heap.
 	useControlStackCache := callDepth < vm.config.CallStackPreallocationSize
 
 	numParams := len(function.functionType.ParamTypes)
 	numLocals := numParams + len(function.code.locals)
 
-	// Bump-allocate locals from the cache: take numLocals slots at localsTop and
-	// advance it (rewound after the call returns). Nested calls bump further, so
-	// frames never overlap. Only an exhausted cache falls back to the heap.
+	// Carve this frame's locals at the cursor; nested calls bump past them, so
+	// frames never overlap.
 	localsMark := vm.localsTop
 	var locals []value
 	if end := localsMark + numLocals; end <= len(vm.localsCache) {
@@ -309,7 +307,7 @@ func (vm *vm) invokeWasmFunction(function *wasmFunction) error {
 			clear(locals[numParams:])
 		}
 	} else {
-		// Cache exhausted: heap allocate (make already zeroes the locals).
+		// Not enough cache room: heap allocate (make already zeroes the locals).
 		locals = make([]value, numLocals)
 		if function.code.defaultLocals != nil {
 			copy(locals[numParams:], function.code.defaultLocals)


### PR DESCRIPTION
## Summary

A set of allocation-focused optimizations in the module parser and the VM call path. No behavior changes — only how buffers are allocated and reused.

- **Zero-allocation limited reader** (`limitedByteReader`) replaces `io.LimitReader` + `bufio.NewReader` when bounding a function body, removing the per-function buffer allocation and the need to drain pre-fetched bytes.
- **Direct reader reuse**: `newParser` reuses the caller's reader when it already implements `io.Reader`+`io.ByteReader` (e.g. `bytes.Reader`) instead of always wrapping it in a `bufio.Reader`.
- **`readCode` buffer sizing**: preallocate the flat bytecode slice from the body's declared size, capped at `maxInitialCapacity` so an attacker-controlled size can't force a large up-front allocation.
- **Lazy jump caches**: a function with no control flow no longer allocates the `jumpCache`/`jumpElseCache` maps; they're created on the first `block`/`loop`/`if`.
- **Bump-allocated locals**: the VM carves each call's locals from a shared `localsCache` via a `localsTop` cursor (rewound on return) instead of a fixed per-depth slot, so frames with many locals can use the cache instead of the heap.
- **Reused validation locals buffer**: `validateFunction` appends into a reused `v.locals` buffer rather than allocating a fresh slice (also avoids the latent aliasing of `append(functionType.ParamTypes, …)` into the shared type definition).

> Host-call argument isolation tests that originated on this branch were split out into #76, since they cover behavior already present on `main` and aren't part of these allocation changes.

## Benchmarks

`benchstat`, 6 runs each, `benchtime=1s`, on `main` vs this branch (Apple M4 Max, darwin/arm64).

### Time (sec/op)

```
                          main          branch        vs base
FactorialRecursive-14     3.405m ± 2%   3.362m ± 2%        ~ (p=0.240)
FactorialIterative-14     5.542m ± 2%   5.521m ± 2%        ~ (p=0.485)
FibonacciRecursive-14     26.11m ± 0%   26.02m ± 0%        ~ (p=0.132)
FibonacciIterative-14     3.992m ± 0%   3.994m ± 1%        ~ (p=0.394)
Indirect-14               616.6µ ± 1%   628.3µ ± 1%   +1.89% (p=0.002)
MatrixMultiplication-14    1.358 ± 0%    1.343 ± 1%   -1.12% (p=0.009)
VectorMath-14             8.756m ± 1%   8.734m ± 1%        ~ (p=0.589)
MemoryAccess-14           745.5m ± 1%   752.1m ± 2%        ~ (p=0.132)
TrigonometrySin-14        898.6n ± 1%   914.4n ± 1%   +1.76% (p=0.002)
SortingBubbleSort-14      41.24m ± 1%   41.41m ± 1%        ~ (p=0.485)
SortingMergeSort-14       4.568m ± 0%   4.498m ± 1%   -1.51% (p=0.002)
SortingQuickSort-14       1.129m ± 1%   1.140m ± 1%   +0.94% (p=0.015)
HostCall-14               816.2µ ± 0%   820.6µ ± 1%        ~ (p=0.093)
InstantiateSmall-14       47.27µ ± 4%   37.26µ ± 6%  -21.18% (p=0.002)
InstantiateLarge-14       163.6µ ± 1%   138.1µ ± 0%  -15.60% (p=0.002)
SHA256-14                  1.835 ± 1%    1.876 ± 1%   +2.25% (p=0.002)
geomean                   4.452m        4.350m        -2.29%
```

### Allocated bytes (B/op)

```
                          main          branch        vs base
VectorMath-14             788.00 ± 0%    20.00 ± 0%  -97.46% (p=0.002)
SortingMergeSort-14     1280.2Ki ± 0%  874.1Ki ± 0%  -31.72% (p=0.002)
InstantiateSmall-14      673.0Ki ± 0%  637.8Ki ± 0%   -5.22% (p=0.002)
InstantiateLarge-14      942.2Ki ± 0%  773.0Ki ± 0%  -17.96% (p=0.002)
SHA256-14                 448.00 ± 0%    32.00 ± 0%  -92.86% (p=0.002)
(other benchmarks unchanged)
```

### Allocations (allocs/op)

```
                          main          branch        vs base
VectorMath-14             3.000 ± 0%    2.000 ± 0%  -33.33% (p=0.002)
SortingMergeSort-14       3.997k ± 0%   1.998k ± 0%  -50.01% (p=0.002)
InstantiateSmall-14       220.0 ± 0%    165.0 ± 0%  -25.00% (p=0.002)
InstantiateLarge-14       451.0 ± 0%    293.0 ± 0%  -35.03% (p=0.002)
SHA256-14                 3.000 ± 0%    2.000 ± 0%  -33.33% (p=0.002)
(other benchmarks unchanged)
```

Net: large allocation cuts on instantiation and on workloads with many calls/locals (allocs geomean -12.97%, B/op geomean -35.22%), with overall time geomean -2.29%. The few sub-2% time movements (`Indirect`, `TrigonometrySin`, `SHA256`, `SortingQuickSort`) are within run-to-run noise and not attributable to a hot-path change.

## Testing

- `go test ./epsilon/` — pass
- `make test` / `make test-spec` for spec coverage

