### PR TITLE
Resolve wasip1 sandbox paths with os.Root

### DIFF
--- a/wasip1/wasi_resources.go
+++ b/wasip1/wasi_resources.go
@@ -30,7 +30,10 @@ const maxFileDescriptors = 2048
 var errMaxFileDescriptorsReached = errors.New("max file descriptors reached")
 
 type wasiFileDescriptor struct {
-	file             *os.File
+	file *os.File
+	// root is non-nil for directory descriptors: the sandboxed os.Root used to
+	// resolve paths; file is the directory's own handle for fd-level operations.
+	root             *os.Root
 	fileType         uint8
 	flags            uint16
 	rights           int64
@@ -42,6 +45,9 @@ type wasiFileDescriptor struct {
 func (fd *wasiFileDescriptor) close() {
 	if fd.file != os.Stdin && fd.file != os.Stdout && fd.file != os.Stderr {
 		fd.file.Close()
+	}
+	if fd.root != nil {
+		fd.root.Close()
 	}
 }
 
@@ -93,6 +99,7 @@ func newWasiResourceTable(
 
 func newFileDescriptor(
 	file *os.File,
+	root *os.Root,
 	rights, rightsInheriting int64,
 	flags uint16,
 ) (*wasiFileDescriptor, error) {
@@ -107,6 +114,7 @@ func newFileDescriptor(
 
 	return &wasiFileDescriptor{
 		file:             file,
+		root:             root,
 		fileType:         getModeFileType(info.Mode()),
 		flags:            flags,
 		rights:           rights,
@@ -117,8 +125,18 @@ func newFileDescriptor(
 }
 
 func newPreopenFileDescriptor(pre WasiPreopen) (*wasiFileDescriptor, error) {
-	fd, err := newFileDescriptor(pre.File, pre.Rights, pre.RightsInheriting, 0)
+	// Re-root by the preopen's path so the descriptor owns a sandboxed os.Root,
+	// taking ownership of (closing) the originally provided handle.
+	root, handle, err := openRootHandle(os.OpenRoot(pre.File.Name()))
+	pre.File.Close()
 	if err != nil {
+		return nil, err
+	}
+
+	fd, err := newFileDescriptor(handle, root, pre.Rights, pre.RightsInheriting, 0)
+	if err != nil {
+		handle.Close()
+		root.Close()
 		return nil, err
 	}
 	fd.guestPath = pre.GuestPath
@@ -130,7 +148,7 @@ func newStdFileDescriptor(
 	file *os.File,
 	rights int64,
 ) (*wasiFileDescriptor, error) {
-	return newFileDescriptor(file, rights, 0, 0)
+	return newFileDescriptor(file, nil, rights, 0, 0)
 }
 
 func (w *wasiResourceTable) advise(
@@ -570,7 +588,7 @@ func (w *wasiResourceTable) pathCreateDirectory(
 		return errnoFault
 	}
 
-	if err := mkdirat(fd.file, path, 0o755); err != nil {
+	if err := mkdirat(fd.root, path, 0o755); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -591,7 +609,7 @@ func (w *wasiResourceTable) pathFilestatGet(
 	}
 
 	followSymlinks := flags&lookupFlagsSymlinkFollow != 0
-	fs, err := stat(fd.file, path, followSymlinks)
+	fs, err := stat(fd.root, path, followSymlinks)
 	if err != nil {
 		return mapError(err)
 	}
@@ -620,7 +638,7 @@ func (w *wasiResourceTable) pathFilestatSetTimes(
 	}
 
 	followSymlinks := flags&lookupFlagsSymlinkFollow != 0
-	err = utimes(fd.file, path, atim, mtim, fstFlags, followSymlinks)
+	err = utimes(fd.root, path, atim, mtim, fstFlags, followSymlinks)
 	if err != nil {
 		return mapError(err)
 	}
@@ -653,7 +671,7 @@ func (w *wasiResourceTable) pathLink(
 	}
 
 	followSymlinks := oldFlags&lookupFlagsSymlinkFollow != 0
-	err = linkat(oldFd.file, oldPath, followSymlinks, newFd.file, newPath)
+	err = linkat(oldFd.root, oldPath, followSymlinks, newFd.root, newPath)
 	if err != nil {
 		return mapError(err)
 	}
@@ -698,14 +716,21 @@ func (w *wasiResourceTable) pathOpen(
 	}
 
 	followSymlinks := dirflags&lookupFlagsSymlinkFollow != 0
-	rights := uint64(rightsBase)
-	file, err := openat(fd.file, path, followSymlinks, oflags, fdflags, rights)
+	file, childRoot, err := openat(
+		fd.root,
+		path,
+		followSymlinks,
+		oflags,
+		fdflags,
+		uint64(rightsBase),
+	)
 	if err != nil {
 		return mapError(err)
 	}
 
 	newFdIndex, errCode := w.allocateFd(
 		file,
+		childRoot,
 		rightsBase,
 		rightsInheriting,
 		uint16(fdflags),
@@ -740,7 +765,7 @@ func (w *wasiResourceTable) pathReadlink(
 		return errnoFault
 	}
 
-	target, err := readlink(fd.file, path)
+	target, err := readlink(fd.root, path)
 	if err != nil {
 		return mapError(err)
 	}
@@ -771,7 +796,7 @@ func (w *wasiResourceTable) pathRemoveDirectory(
 		return errnoFault
 	}
 
-	if err := rmdirat(fd.file, path); err != nil {
+	if err := rmdirat(fd.root, path); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -801,7 +826,7 @@ func (w *wasiResourceTable) pathRename(
 		return errnoFault
 	}
 
-	if err := renameat(oldFd.file, oldPath, newFd.file, newPath); err != nil {
+	if err := renameat(oldFd.root, oldPath, newFd.root, newPath); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -826,7 +851,7 @@ func (w *wasiResourceTable) pathSymlink(
 		return errnoFault
 	}
 
-	if err := symlinkat(targetPath, fd.file, linkPath); err != nil {
+	if err := symlinkat(targetPath, fd.root, linkPath); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -846,7 +871,7 @@ func (w *wasiResourceTable) pathUnlinkFile(
 		return errnoFault
 	}
 
-	if err := unlinkat(fd.file, path); err != nil {
+	if err := unlinkat(fd.root, path); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -874,6 +899,7 @@ func (w *wasiResourceTable) sockAccept(
 	inheritRights := fd.rightsInheriting
 	newFdIndex, errCode := w.allocateFd(
 		newFile,
+		nil,
 		rights,
 		inheritRights,
 		uint16(flags),
@@ -964,12 +990,16 @@ func (w *wasiResourceTable) allocateFdIndex() (int32, error) {
 // code.
 func (w *wasiResourceTable) allocateFd(
 	file *os.File,
+	root *os.Root,
 	rights, inheritRights int64,
 	flags uint16,
 ) (int32, int32) {
-	fd, err := newFileDescriptor(file, rights, inheritRights, flags)
+	fd, err := newFileDescriptor(file, root, rights, inheritRights, flags)
 	if err != nil {
 		file.Close()
+		if root != nil {
+			root.Close()
+		}
 		return 0, mapError(err)
 	}
 	newFdIndex, err := w.allocateFdIndex()

--- a/wasip1/wasi_resources_test.go
+++ b/wasip1/wasi_resources_test.go
@@ -31,7 +31,7 @@ func TestRightsEscalation_FdSync(t *testing.T) {
 	defer dirFd.Close()
 
 	// Open file WITH RightsFdRead but WITHOUT RightsFdSync
-	f, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("openat failed: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestRightsEscalation_FdFilestatGet(t *testing.T) {
 	_, dirFd := testFS(t, file("test.txt", "hello"))
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("openat failed: %v", err)
 	}

--- a/wasip1/wasi_sys_unix.go
+++ b/wasip1/wasi_sys_unix.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -28,9 +30,6 @@ import (
 
 	"golang.org/x/sys/unix"
 )
-
-// maxSymlinkDepth is the maximum number of symlink resolutions allowed.
-const maxSymlinkDepth = 40
 
 // defaultFileMode is the default permission mode for newly created files.
 const defaultFileMode = 0o600
@@ -67,58 +66,51 @@ func init() {
 // This is similar to mkdirat in POSIX.
 //
 // Parameters:
-//   - dir: the directory os.File to create relative to
-//   - path: the relative path of the directory to create
+//   - root: the os.Root to create relative to
+//   - name: the relative path of the directory to create
 //   - mode: the file mode bits for the new directory
 //
 // Returns an error if the operation fails.
-func mkdirat(dir *os.File, path string, mode uint32) error {
-	if !isRelativePath(path) {
+func mkdirat(root *os.Root, name string, mode uint32) error {
+	if name == "." || !filepath.IsLocal(name) {
 		return os.ErrInvalid
 	}
-
-	components, err := getComponents(path)
-	if err != nil {
-		return err
-	}
-
-	if len(components) == 1 && components[0] == "." {
-		return os.ErrInvalid
-	}
-
-	parentFd, _, _, err := walkToParent(dir, components, 0)
-	if err != nil {
-		return err
-	}
-
-	if parentFd != int(dir.Fd()) {
-		defer unix.Close(parentFd)
-	}
-
-	return unix.Mkdirat(parentFd, components[len(components)-1], mode)
+	return root.Mkdir(name, fs.FileMode(mode))
 }
 
 // stat returns the filestat of a file or directory relative to a directory.
 // This is similar to fstatat in POSIX.
 //
 // Parameters:
-//   - dir: the directory os.File to stat relative to
-//   - path: the relative path of the file or directory to inspect
+//   - root: the os.Root to stat relative to
+//   - name: the relative path of the file or directory to inspect
 //   - followSymlinks: whether to follow final symlink
 //
 // Returns the filestat and an error if the operation fails.
-func stat(dir *os.File, path string, followSymlinks bool) (filestat, error) {
-	dirFd, fileName, err := resolvePath(dir, path, followSymlinks, 0)
+func stat(
+	root *os.Root,
+	name string,
+	followSymlinks bool,
+) (filestat, error) {
+	atFlags := unix.AT_SYMLINK_NOFOLLOW
+	if followSymlinks {
+		// os.Root.Stat gates the follow-mode Fstatat: it fails if the followed
+		// leaf escapes the root. No-follow needs no gate (NOFOLLOW never
+		// dereferences the leaf).
+		if _, err := root.Stat(name); err != nil {
+			return filestat{}, err
+		}
+		atFlags = 0
+	}
+
+	parent, base, err := leafParent(root, name)
 	if err != nil {
 		return filestat{}, err
 	}
-	if dirFd != int(dir.Fd()) {
-		defer unix.Close(dirFd)
-	}
+	defer parent.Close()
 
 	var statBuf unix.Stat_t
-	flags := unix.AT_SYMLINK_NOFOLLOW
-	if err := unix.Fstatat(dirFd, fileName, &statBuf, flags); err != nil {
+	if err := unix.Fstatat(int(parent.Fd()), base, &statBuf, atFlags); err != nil {
 		return filestat{}, err
 	}
 	return statFromUnix(&statBuf), nil
@@ -200,8 +192,8 @@ func setFdFlags(file *os.File, fdFlags int32) error {
 // This is similar to utimensat in POSIX.
 //
 // Parameters:
-//   - dir: the directory os.File to resolve relative to
-//   - path: the relative path of the file or directory
+//   - root: the os.Root to resolve relative to
+//   - name: the relative path of the file or directory
 //   - atim: access time in nanoseconds (used if fstFlagsAtim is set)
 //   - mtim: modification time in nanoseconds (used if fstFlagsMtim is set)
 //   - fstFlags: bitmask controlling which times to set and how
@@ -209,8 +201,8 @@ func setFdFlags(file *os.File, fdFlags int32) error {
 //
 // Returns an error if the operation fails.
 func utimes(
-	dir *os.File,
-	path string,
+	root *os.Root,
+	name string,
 	atim, mtim int64,
 	fstFlags int32,
 	followSymlinks bool,
@@ -220,15 +212,23 @@ func utimes(
 		return err
 	}
 
-	dirFd, fileName, err := resolvePath(dir, path, followSymlinks, 0)
+	atFlags := unix.AT_SYMLINK_NOFOLLOW
+	if followSymlinks {
+		// Gate the follow-mode UtimesNanoAt (which follows the leaf via the
+		// kernel) so it cannot escape the root.
+		if _, err := root.Stat(name); err != nil {
+			return err
+		}
+		atFlags = 0
+	}
+
+	parent, base, err := leafParent(root, name)
 	if err != nil {
 		return err
 	}
-	if dirFd != int(dir.Fd()) {
-		defer unix.Close(dirFd)
-	}
+	defer parent.Close()
 
-	return unix.UtimesNanoAt(dirFd, fileName, times, unix.AT_SYMLINK_NOFOLLOW)
+	return unix.UtimesNanoAt(int(parent.Fd()), base, times, atFlags)
 }
 
 func utimesNanoAt(file *os.File, atim, mtim int64, fstFlags int32) error {
@@ -260,117 +260,118 @@ func writeAt(
 // This is similar to linkat in POSIX.
 //
 // Parameters:
-//   - oldDir: the directory os.File for the source path resolution
-//   - oldPath: the relative path of the source file
-//   - followSymlinks: whether to follow symlinks when resolving oldPath
-//   - newDir: the directory os.File for the destination path resolution
-//   - newPath: the relative path for the new hard link
+//   - oldRoot: the os.Root for the source path resolution
+//   - oldName: the relative path of the source file
+//   - followSymlinks: whether to follow symlinks when resolving oldName
+//   - newRoot: the os.Root for the destination path resolution
+//   - newName: the relative path for the new hard link
 //
 // Returns an error if the operation fails.
 func linkat(
-	oldDir *os.File,
-	oldPath string,
+	oldRoot *os.Root,
+	oldName string,
 	followSymlinks bool,
-	newDir *os.File,
-	newPath string,
+	newRoot *os.Root,
+	newName string,
 ) error {
 	// Hard link creation does not support directory targets (implied by trailing
 	// slash)
-	if strings.HasSuffix(oldPath, string(filepath.Separator)) ||
-		strings.HasSuffix(newPath, string(filepath.Separator)) {
+	if strings.HasSuffix(oldName, "/") || strings.HasSuffix(newName, "/") {
 		return syscall.ENOENT
 	}
 
-	oldDirFd, oldName, err := resolvePath(oldDir, oldPath, followSymlinks, 0)
+	// Linkat with AT_SYMLINK_FOLLOW follows the source leaf via the kernel,
+	// which could escape the root. Validate through os.Root first.
+	var flags int
+	if followSymlinks {
+		if _, err := oldRoot.Stat(oldName); err != nil {
+			return err
+		}
+		flags = unix.AT_SYMLINK_FOLLOW
+	}
+
+	oldParent, oldBase, err := leafParent(oldRoot, oldName)
 	if err != nil {
 		return err
 	}
-	if oldDirFd != int(oldDir.Fd()) {
-		defer unix.Close(oldDirFd)
-	}
+	defer oldParent.Close()
 
-	newDirFd, newName, err := resolvePath(newDir, newPath, false, 0)
+	newParent, newBase, err := leafParent(newRoot, newName)
 	if err != nil {
 		return err
 	}
-	if newDirFd != int(newDir.Fd()) {
-		defer unix.Close(newDirFd)
-	}
+	defer newParent.Close()
 
-	return unix.Linkat(oldDirFd, oldName, newDirFd, newName, 0)
+	return unix.Linkat(
+		int(oldParent.Fd()), oldBase,
+		int(newParent.Fd()), newBase,
+		flags,
+	)
 }
 
 // readlink reads the contents of a symbolic link.
 // This is similar to readlinkat in POSIX.
 //
 // Parameters:
-//   - dir: the directory os.File to resolve relative to
-//   - path: the relative path of the symbolic link
+//   - root: the os.Root to resolve relative to
+//   - name: the relative path of the symbolic link
 //
 // Returns the symlink target and an error if the operation fails.
-func readlink(dir *os.File, path string) (string, error) {
-	dirFd, name, err := resolvePath(dir, path, false, 0)
-	if err != nil {
-		return "", err
-	}
-	if dirFd != int(dir.Fd()) {
-		defer unix.Close(dirFd)
-	}
-	return readlinkat(dirFd, name)
+func readlink(root *os.Root, name string) (string, error) {
+	return root.Readlink(name)
 }
 
 // rmdirat removes an empty directory.
 // This is similar to unlinkat(fd, path, AT_REMOVEDIR) in POSIX.
 //
 // Parameters:
-//   - dir: the directory os.File to resolve relative to
-//   - path: the relative path of the directory to remove
+//   - root: the os.Root to resolve relative to
+//   - name: the relative path of the directory to remove
 //
 // Returns an error if the operation fails (e.g., ENOTEMPTY if not empty).
-func rmdirat(dir *os.File, path string) error {
-	dirFd, name, err := resolvePath(dir, path, false, 0)
+func rmdirat(root *os.Root, name string) error {
+	// AT_REMOVEDIR yields ENOTDIR on a non-directory and ENOTEMPTY on a non-empty
+	// directory, matching WASI path_remove_directory semantics.
+	parent, base, err := leafParent(root, name)
 	if err != nil {
 		return err
 	}
-	if dirFd != int(dir.Fd()) {
-		defer unix.Close(dirFd)
-	}
-	return unix.Unlinkat(dirFd, name, unix.AT_REMOVEDIR)
+	defer parent.Close()
+	return unix.Unlinkat(int(parent.Fd()), base, unix.AT_REMOVEDIR)
 }
 
 // renameat renames a file or directory.
 // This is similar to renameat in POSIX.
 //
 // Parameters:
-//   - oldDir: the directory os.File for the source path resolution
-//   - oldPath: the relative path of the source file or directory
-//   - newDir: the directory os.File for the destination path resolution
-//   - newPath: the relative path of the destination
+//   - oldRoot: the os.Root for the source path resolution
+//   - oldName: the relative path of the source file or directory
+//   - newRoot: the os.Root for the destination path resolution
+//   - newName: the relative path of the destination
 //
 // Returns an error if the operation fails.
 func renameat(
-	oldDir *os.File,
-	oldPath string,
-	newDir *os.File,
-	newPath string,
+	oldRoot *os.Root,
+	oldName string,
+	newRoot *os.Root,
+	newName string,
 ) error {
-	oldDirFd, oldName, err := resolvePath(oldDir, oldPath, false, 0)
+	oldParent, oldBase, err := leafParent(oldRoot, oldName)
 	if err != nil {
 		return err
 	}
-	if oldDirFd != int(oldDir.Fd()) {
-		defer unix.Close(oldDirFd)
-	}
+	defer oldParent.Close()
 
-	newDirFd, newName, err := resolvePath(newDir, newPath, false, 0)
+	newParent, newBase, err := leafParent(newRoot, newName)
 	if err != nil {
 		return err
 	}
-	if newDirFd != int(newDir.Fd()) {
-		defer unix.Close(newDirFd)
-	}
+	defer newParent.Close()
 
-	return unix.Renameat(oldDirFd, oldName, newDirFd, newName)
+	return unix.Renameat(
+		int(oldParent.Fd()), oldBase,
+		int(newParent.Fd()), newBase,
+	)
 }
 
 // symlinkat creates a symbolic link.
@@ -378,148 +379,108 @@ func renameat(
 //
 // Parameters:
 //   - target: the contents of the symbolic link (what it points to)
-//   - dir: the directory os.File for the link path resolution
-//   - path: the relative path at which to create the symlink
+//   - root: the os.Root for the link path resolution
+//   - name: the relative path at which to create the symlink
 //
 // Returns an error if the operation fails.
-func symlinkat(target string, dir *os.File, path string) error {
-	if strings.HasPrefix(target, string(filepath.Separator)) {
+func symlinkat(target string, root *os.Root, name string) error {
+	if strings.HasPrefix(target, "/") {
 		return syscall.EPERM
 	}
-
-	if strings.HasSuffix(path, string(filepath.Separator)) {
+	if strings.HasSuffix(name, "/") {
 		return syscall.ENOENT
 	}
-
-	dirFd, name, err := resolvePath(dir, path, false, 0)
-	if err != nil {
-		return err
-	}
-	if dirFd != int(dir.Fd()) {
-		defer unix.Close(dirFd)
-	}
-
-	return unix.Symlinkat(target, dirFd, name)
+	return root.Symlink(target, name)
 }
 
 // unlinkat removes a file (but not a directory).
 // This is similar to unlinkat(fd, path, 0) in POSIX.
 //
 // Parameters:
-//   - dir: the directory os.File to resolve relative to
-//   - path: the relative path of the file to unlink
+//   - root: the os.Root to resolve relative to
+//   - name: the relative path of the file to unlink
 //
 // Returns EISDIR if the path refers to a directory.
-func unlinkat(dir *os.File, path string) error {
-	dirFd, name, err := resolvePath(dir, path, false, 0)
+func unlinkat(root *os.Root, name string) error {
+	// Without AT_REMOVEDIR, unlinkat yields EISDIR/EPERM on a directory, matching
+	// WASI path_unlink_file semantics.
+	parent, base, err := leafParent(root, name)
 	if err != nil {
 		return err
 	}
-	if dirFd != int(dir.Fd()) {
-		defer unix.Close(dirFd)
-	}
-
-	// Restore trailing slash so syscall returns correct error
-	if strings.HasSuffix(path, string(filepath.Separator)) {
-		name += string(filepath.Separator)
-	}
-
-	return unix.Unlinkat(dirFd, name, 0)
+	defer parent.Close()
+	return unix.Unlinkat(int(parent.Fd()), base, 0)
 }
 
 // openat opens a file or directory relative to a directory.
 // This is similar to openat in POSIX.
 //
 // Parameters:
-//   - dir: the directory os.File to open relative to
-//   - path: the relative path of the file or directory to open
+//   - root: the os.Root to open relative to
+//   - name: the relative path of the file or directory to open
 //   - followSymlinks: whether to follow final symlink
 //   - oflags: flags determining the method by which to open the file
-//   - fsRightsBase: base rights for operations using the returned os.File
+//   - fsRights: base rights for operations using the returned os.File
 //   - fdflags: file descriptor flags
 //
-// The implementation may return an os.File with fewer rights than specified,
-// if and only if those rights do not apply to the type of file being opened.
-//
-// Returns the opened os.File and an error if the operation fails.
+// A directory (requested via O_DIRECTORY or a trailing slash, or discovered
+// after opening) is returned as its own sandboxed os.Root in childRoot, with
+// file as its directory handle; a regular file is returned in file with
+// childRoot nil.
 func openat(
-	dir *os.File,
-	path string,
+	root *os.Root,
+	name string,
 	followSymlinks bool,
 	oflags, fdflags int32,
 	fsRights uint64,
-) (*os.File, error) {
-	// A trailing slash means the path must be a directory.
-	// We detect this before calling resolvePath because we lose that info.
-	if strings.HasSuffix(path, string(filepath.Separator)) {
-		oflags |= int32(oFlagsDirectory)
+) (file *os.File, childRoot *os.Root, err error) {
+	// A trailing slash or an explicit O_DIRECTORY means the path must be a
+	// directory, which becomes its own sandboxed root.
+	if oflags&int32(oFlagsDirectory) != 0 || strings.HasSuffix(name, "/") {
+		// A directory cannot be opened for writing.
+		if fsRights&uint64(RightsFdWrite) != 0 {
+			return nil, nil, syscall.EISDIR
+		}
+		// Without symlink-follow, a symlink named as a directory must not be
+		// followed; opening it as a directory fails.
+		if !followSymlinks && isSymlinkLeaf(root, name) {
+			return nil, nil, syscall.ELOOP
+		}
+		childRoot, file, err = openRootHandle(root.OpenRoot(name))
+		return file, childRoot, err
 	}
 
-	dirFd, name, err := resolvePath(dir, path, followSymlinks, 0)
+	// os.Root.OpenFile follows a final symlink within the root, so for no-follow
+	// reject a symlink leaf explicitly. O_EXCL never follows.
+	if !followSymlinks && oflags&int32(oFlagsExcl) == 0 && isSymlinkLeaf(root, name) {
+		return nil, nil, syscall.ELOOP
+	}
+
+	file, err = root.OpenFile(name, openMode(fsRights, oflags, fdflags), defaultFileMode)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var parentDir *os.File
-	if dirFd == int(dir.Fd()) {
-		parentDir = dir
-	} else {
-		parentDir = os.NewFile(uintptr(dirFd), "")
-		defer parentDir.Close()
-	}
-
-	// Determine read/write mode from rights
-	canRead := fsRights&uint64(RightsFdRead) != 0
-	canWrite := fsRights&uint64(RightsFdWrite) != 0
-
-	flags := unix.O_CLOEXEC | unix.O_NOFOLLOW
-	switch {
-	case canRead && canWrite:
-		flags |= unix.O_RDWR
-	case canWrite:
-		flags |= unix.O_WRONLY
-	default:
-		flags |= unix.O_RDONLY
-	}
-
-	// Convert WASI oflags to Unix flags
-	if oflags&int32(oFlagsCreat) != 0 {
-		flags |= unix.O_CREAT
-	}
-	if oflags&int32(oFlagsDirectory) != 0 {
-		flags |= unix.O_DIRECTORY
-	}
-	if oflags&int32(oFlagsExcl) != 0 {
-		flags |= unix.O_EXCL
-	}
-	if oflags&int32(oFlagsTrunc) != 0 {
-		flags |= unix.O_TRUNC
-	}
-
-	// Convert WASI fdflags to Unix flags
-	if fdflags&int32(fdFlagsAppend) != 0 {
-		flags |= unix.O_APPEND
-	}
-	if fdflags&int32(fdFlagsDsync) != 0 {
-		flags |= unix.O_DSYNC
-	}
-	if fdflags&int32(fdFlagsNonblock) != 0 {
-		flags |= unix.O_NONBLOCK
-	}
-	if fdflags&int32(fdFlagsSync) != 0 {
-		flags |= unix.O_SYNC
-	}
-	// Note: fdFlagsRsync maps to O_RSYNC, which equals O_SYNC on most systems.
-	if fdflags&int32(fdFlagsRsync) != 0 {
-		flags |= unix.O_SYNC
-	}
-
-	fd, err := unix.Openat(int(parentDir.Fd()), name, flags, defaultFileMode)
+	// A directory may be opened without O_DIRECTORY; promote it to a root so
+	// subsequent path operations on the descriptor work.
+	info, err := file.Stat()
 	if err != nil {
-		return nil, err
+		file.Close()
+		return nil, nil, err
 	}
+	if info.IsDir() {
+		file.Close()
+		childRoot, file, err = openRootHandle(root.OpenRoot(name))
+		return file, childRoot, err
+	}
+	return file, nil, nil
+}
 
-	return os.NewFile(uintptr(fd), name), nil
+// isSymlinkLeaf reports whether name's final component is a symlink. Intermediate
+// components are resolved within root.
+func isSymlinkLeaf(root *os.Root, name string) bool {
+	info, err := root.Lstat(name)
+	return err == nil && info.Mode()&fs.ModeSymlink != 0
 }
 
 // accept accepts a connection on the socket file descriptor.
@@ -542,276 +503,100 @@ func shutdown(file *os.File, how int32) error {
 	}
 }
 
-// walkToParent walks through intermediate path components (all except the last)
-// and returns the fd of the parent directory of the final component.
-// Symlinks in intermediate components are followed securely within the sandbox.
-//
-// Parameters:
-//   - dir: the sandbox root directory (symlinks are resolved relative to this)
-//   - components: the path components to walk
-//   - depth: current symlink resolution depth
-//
-// Returns:
-//   - parentFd: fd of the parent directory
-//   - parentPath: the path of parentFd relative to dir
-//   - newDepth: updated symlink resolution depth
-//   - error: any error encountered
-//
-// The caller is responsible for closing parentFd if it differs from dir.Fd().
-func walkToParent(
-	dir *os.File,
-	components []string,
-	depth int,
-) (int, string, int, error) {
-	if depth >= maxSymlinkDepth {
-		return 0, "", depth, syscall.ELOOP
-	}
-
-	dirFd := int(dir.Fd())
-	parentFd := dirFd
-	parentPath := ""
-
-	// Helper to close parentFd if it differs from dir.Fd
-	closeParent := func() {
-		if parentFd != dirFd {
-			unix.Close(parentFd)
-		}
-	}
-
-	// Re-calculates path components and restarts the walk from root
-	restart := func(newBase string, remain []string) (int, string, int, error) {
-		closeParent()
-
-		newComponents := append(splitPath(newBase), remain...)
-		if len(newComponents) == 0 {
-			newComponents = []string{"."}
-		}
-
-		return walkToParent(dir, newComponents, depth+1)
-	}
-
-	for i, component := range components[:len(components)-1] {
-		if component == "." {
-			continue
-		}
-
-		if component == ".." {
-			// Check if we're at the root, we cannot go above sandbox
-			if parentPath == "" {
-				return 0, "", depth, syscall.EPERM
-			}
-			newParentPath := filepath.Dir(parentPath)
-			if newParentPath == "." {
-				newParentPath = ""
-			}
-			return restart(newParentPath, components[i+1:])
-		}
-
-		mode := unix.O_RDONLY | unix.O_NOFOLLOW | unix.O_DIRECTORY | unix.O_CLOEXEC
-		newFd, err := unix.Openat(parentFd, component, mode, 0)
-
-		// If Openat fails, check if the component is a symlink we need to resolve.
-		// O_NOFOLLOW typically returns ELOOP for symlinks. However, when combined
-		// with O_DIRECTORY, some systems may return ENOTDIR if the symlink points
-		// to a non-directory file.
-		if errors.Is(err, syscall.ELOOP) || errors.Is(err, syscall.ENOTDIR) {
-			resolvedPath, symErr := resolveSymlink(parentFd, parentPath, component)
-			if symErr != nil {
-				closeParent()
-				// If it's not a symlink, return the original error
-				return 0, "", depth, err
-			}
-			return restart(resolvedPath, components[i+1:])
-		}
-
-		closeParent()
-		if err != nil {
-			return 0, "", depth, err
-		}
-
-		parentFd = newFd
-		parentPath = filepath.Join(parentPath, component)
-	}
-
-	return parentFd, parentPath, depth, nil
-}
-
-func getComponents(path string) ([]string, error) {
-	components := splitPath(path)
-	if len(components) == 0 {
-		return nil, os.ErrInvalid
-	}
-
-	// If the final component is "..", append "." to ensure it's processed as an
-	// intermediate component through safe logical resolution, and we use "." as
-	// the final name for the syscall.
-	if components[len(components)-1] == ".." {
-		components = append(components, ".")
-	}
-
-	return components, nil
-}
-
-// splitPath splits a path into its components without lexically resolving "..".
-// This is critical for security: ".." must be traversed at runtime to enforce
-// permission and existence checks on intermediate directories.
-// It handles both forward slashes and the OS-specific separator.
-func splitPath(path string) []string {
-	parts := strings.FieldsFunc(path, func(r rune) bool {
-		return r == filepath.Separator
-	})
-	if len(parts) == 0 {
-		return []string{"."}
-	}
-	return parts
-}
-
-// isRelativePath checks if a path is a valid relative path for sandbox
-// traversal. It rejects:
-//   - Absolute paths (starting with /)
-//   - Paths that start with .. (immediate sandbox escape)
-//   - Empty paths
-//
-// Unlike filepath.IsLocal, it ALLOWS internal ".." components like "a/../b"
-// because these will be traversed at runtime, enforcing permission checks.
-func isRelativePath(path string) bool {
-	if path == "" {
-		return false
-	}
-	if filepath.IsAbs(path) {
-		return false
-	}
-	// Check if path starts with ".."
-	if path == ".." || strings.HasPrefix(path, ".."+string(filepath.Separator)) {
-		return false
-	}
-	return true
-}
-
-// resolveSymlink reads a symlink and returns a sandbox-safe resolved path.
-//
-// Parameters:
-//   - parentFd: fd of the directory containing the symlink
-//   - parentPath: path of parentFd relative to the sandbox root
-//   - name: name of the symlink within the parent directory
-//
-// Returns the resolved path relative to the sandbox root. Absolute symlink
-// targets are resolved relative to the sandbox root (not the filesystem root),
-// while relative targets are resolved relative to parentPath.
-//
-// Returns EPERM if the resolved path would escape the sandbox.
-func resolveSymlink(parentFd int, parentPath, name string) (string, error) {
-	target, err := readlinkat(parentFd, name)
+// openRootHandle opens root's own "." handle, closing root on failure. It
+// threads the error from os.OpenRoot so callers can write
+// openRootHandle(os.OpenRoot(dir)).
+func openRootHandle(root *os.Root, err error) (*os.Root, *os.File, error) {
 	if err != nil {
-		return "", err
+		return nil, nil, err
 	}
-
-	var resolved string
-	if filepath.IsAbs(target) {
-		resolved = strings.TrimPrefix(target, string(filepath.Separator))
-	} else {
-		resolved = filepath.Clean(filepath.Join(parentPath, target))
+	handle, err := root.Open(".")
+	if err != nil {
+		root.Close()
+		return nil, nil, err
 	}
-	if !filepath.IsLocal(resolved) {
-		return "", syscall.EPERM
-	}
-	return resolved, nil
+	return root, handle, nil
 }
 
-// readlinkat reads a symlink target, growing the buffer as needed.
-func readlinkat(dirFd int, name string) (string, error) {
-	buf := make([]byte, 256)
-	for {
-		n, err := unix.Readlinkat(dirFd, name, buf)
-		if err != nil {
-			return "", err
-		}
-		if n < len(buf) {
-			return string(buf[:n]), nil
-		}
-		buf = make([]byte, len(buf)*2)
+// leafParent opens name's parent directory through os.Root and returns its
+// handle and the single-component leaf. The caller must close parent.
+func leafParent(
+	root *os.Root,
+	name string,
+) (parent *os.File, base string, err error) {
+	// Preserve a trailing slash on the leaf so the kernel enforces directory
+	// semantics (e.g. unlinking "file/" yields ENOTDIR, removing "dir/" still
+	// succeeds).
+	trailingSlash := strings.HasSuffix(name, "/")
+	dir, base := path.Split(strings.TrimRight(name, "/"))
+	dir = strings.TrimSuffix(dir, "/")
+	if trailingSlash {
+		base += "/"
 	}
+	if dir == "" {
+		dir = "."
+	}
+
+	// os.Root only guards the parent (dir); the leaf is passed straight to the
+	// raw *at syscall, which has no sandbox awareness. A non-local leaf escapes:
+	// ".." climbs above the parent, and an absolute leaf ("/") makes *at ignore
+	// the dir fd and resolve from the host root. Reject anything that is not a
+	// safe in-directory name. A trailing slash is kept on the leaf for the kernel
+	// (filepath.IsLocal cleans it away, so "dir/" stays allowed).
+	if !filepath.IsLocal(base) {
+		return nil, "", syscall.EPERM
+	}
+	parent, err = root.Open(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	return parent, base, nil
 }
 
-// resolvePath resolves a path relative to a directory os.File. It returns the
-// file descriptor of the parent directory and the file or directory name.
-//
-// It does so by securely resolving path relative to dirFd, following symlinks
-// in intermediate components and, if followSymlinks is true, in the final
-// component.
-//
-// If the final path component does not exist, it returns success (and ENOENT
-// checks are deferred to the caller), which allows support for O_CREAT.
-//
-// All of this is done while never escaping the sandbox root.
-func resolvePath(
-	dir *os.File,
-	path string,
-	followSymlinks bool,
-	depth int,
-) (int, string, error) {
-	if depth >= maxSymlinkDepth {
-		return 0, "", syscall.ELOOP
+func openMode(rights uint64, oflags, fdflags int32) int {
+	// Determine read/write mode from rights
+	canRead := rights&uint64(RightsFdRead) != 0
+	canWrite := rights&uint64(RightsFdWrite) != 0
+
+	var flag int
+	switch {
+	case canRead && canWrite:
+		flag = os.O_RDWR
+	case canWrite:
+		flag = os.O_WRONLY
+	default:
+		flag = os.O_RDONLY
 	}
 
-	if !isRelativePath(path) {
-		return 0, "", syscall.EPERM
+	// Convert WASI oflags to Unix flags
+	if oflags&int32(oFlagsCreat) != 0 {
+		flag |= os.O_CREATE
+	}
+	if oflags&int32(oFlagsDirectory) != 0 {
+		flag |= syscall.O_DIRECTORY
+	}
+	if oflags&int32(oFlagsExcl) != 0 {
+		flag |= os.O_EXCL
+	}
+	if oflags&int32(oFlagsTrunc) != 0 {
+		flag |= os.O_TRUNC
 	}
 
-	comps, err := getComponents(path)
-	if err != nil {
-		return 0, "", err
+	// Convert WASI fdflags to Unix flags
+	if fdflags&int32(fdFlagsAppend) != 0 {
+		flag |= os.O_APPEND
 	}
-
-	// Handle special case of stat on "." (the directory itself)
-	if len(comps) == 1 && comps[0] == "." {
-		return int(dir.Fd()), ".", nil
+	if fdflags&int32(fdFlagsDsync) != 0 {
+		flag |= syscall.O_DSYNC
 	}
-
-	parentFd, parentPath, newDepth, err := walkToParent(dir, comps, depth)
-	if err != nil {
-		return 0, "", err
+	if fdflags&int32(fdFlagsNonblock) != 0 {
+		flag |= syscall.O_NONBLOCK
 	}
-
-	// closeParent closes parentFd if we own it (differs from dir.Fd). We cannot
-	// use defer because we may return parentFd to the caller.
-	closeParent := func() {
-		if parentFd != int(dir.Fd()) {
-			unix.Close(parentFd)
-		}
+	// fdFlagsRsync maps to O_RSYNC, which equals O_SYNC on most systems.
+	if fdflags&int32(fdFlagsSync) != 0 || fdflags&int32(fdFlagsRsync) != 0 {
+		flag |= syscall.O_SYNC
 	}
-
-	finalName := comps[len(comps)-1]
-
-	// Always stat with AT_SYMLINK_NOFOLLOW first to check if it's a symlink
-	var statBuf unix.Stat_t
-	err = unix.Fstatat(parentFd, finalName, &statBuf, unix.AT_SYMLINK_NOFOLLOW)
-
-	// If the error is ENOENT, the file doesn't exist. We return success (for
-	// O_CREAT support)
-	if errors.Is(err, syscall.ENOENT) {
-		return parentFd, finalName, nil
-	}
-
-	if err != nil {
-		closeParent()
-		return 0, "", err
-	}
-
-	// If it's not a symlink, or we don't want to follow, return immediately
-	if statBuf.Mode&unix.S_IFMT != unix.S_IFLNK || !followSymlinks {
-		return parentFd, finalName, nil
-	}
-
-	// It's a symlink and we need to follow it securely.
-	resolvedPath, err := resolveSymlink(parentFd, parentPath, finalName)
-	closeParent()
-	if err != nil {
-		return 0, "", err
-	}
-
-	// Restart resolution with the new target and updated depth
-	return resolvePath(dir, resolvedPath, followSymlinks, newDepth+1)
+	return flag
 }
 
 // statFromUnix converts a unix.Stat_t to a filestat.
@@ -878,13 +663,32 @@ func buildTimespec(atim, mtim int64, fstFlags int32) ([]unix.Timespec, error) {
 	return []unix.Timespec{atimSpec, mtimSpec}, nil
 }
 
-// mapError maps Go/Syscall errors to WASI errno.
+// mapError maps Go, io/fs, and syscall errors to a WASI errno.
 func mapError(err error) int32 {
-	if unwrapped := errors.Unwrap(err); unwrapped != nil {
-		err = unwrapped
+	if err == nil {
+		return errnoSuccess
 	}
 
-	if errno, ok := err.(syscall.Errno); ok {
+	// os.Root reports these conditions through a *fs.PathError wrapping an
+	// unexported errors.New sentinel, so the inner message is the only thing that
+	// distinguishes them. Sandbox escapes and empty paths map to errnoPerm to
+	// match the previous hand-rolled resolver.
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		switch pathErr.Err.Error() {
+		case "path escapes from parent", "empty path":
+			return errnoPerm
+		case "not a directory":
+			return errnoNotDir
+		}
+	}
+
+	// Match the specific syscall.Errno before the broader io/fs sentinels:
+	// syscall.Errno.Is maps several distinct errnos onto the same fs sentinel
+	// (e.g. both EEXIST and ENOTEMPTY satisfy fs.ErrExist), which would
+	// otherwise lose the distinction WASI requires.
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
 		switch errno {
 		case syscall.EACCES:
 			return errnoAcces
@@ -915,6 +719,17 @@ func mapError(err error) int32 {
 		case syscall.EAGAIN:
 			return errnoAgain
 		}
+	}
+
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return errnoNoEnt
+	case errors.Is(err, fs.ErrExist):
+		return errnoExist
+	case errors.Is(err, fs.ErrPermission):
+		return errnoAcces
+	case errors.Is(err, fs.ErrInvalid):
+		return errnoInval
 	}
 
 	return errnoNotCapable

--- a/wasip1/wasi_sys_unix_test.go
+++ b/wasip1/wasi_sys_unix_test.go
@@ -47,9 +47,9 @@ func link(path, target string) fsEntry {
 }
 
 // testFS creates a filesystem structure for testing and returns the root
-// directory path and os.File. The caller must close the returned *os.File.
-// Parent directories are created automatically.
-func testFS(t *testing.T, entries ...fsEntry) (string, *os.File) {
+// directory path and a sandboxed os.Root. The caller must close the returned
+// *os.Root. Parent directories are created automatically.
+func testFS(t *testing.T, entries ...fsEntry) (string, *os.Root) {
 	t.Helper()
 	root := t.TempDir()
 
@@ -78,7 +78,7 @@ func testFS(t *testing.T, entries ...fsEntry) (string, *os.File) {
 		}
 	}
 
-	dirFd, err := os.Open(root)
+	dirFd, err := os.OpenRoot(root)
 	if err != nil {
 		t.Fatalf("failed to open root: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestOpenat_BasicFile(t *testing.T) {
 	_, dirFd := testFS(t, file("test.txt", "hello"))
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen failed: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestOpenat_NestedPath(t *testing.T) {
 	_, dirFd := testFS(t, file("a/b/c/test.txt", "nested"))
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "a/b/c/test.txt", false, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "a/b/c/test.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen failed: %v", err)
 	}
@@ -128,11 +128,12 @@ func TestOpenat_Directory(t *testing.T) {
 	defer dirFd.Close()
 
 	flags := int32(oFlagsDirectory)
-	f, err := openat(dirFd, "subdir", false, flags, 0, uint64(RightsFdRead))
+	f, childRoot, err := openat(dirFd, "subdir", false, flags, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen failed: %v", err)
 	}
 	defer f.Close()
+	defer childRoot.Close()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -147,11 +148,12 @@ func TestOpenat_TrailingSlashOnDirectory(t *testing.T) {
 	_, dirFd := testFS(t, dir("subdir"))
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "subdir/", false, 0, 0, uint64(RightsFdRead))
+	f, childRoot, err := openat(dirFd, "subdir/", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen with trailing slash on directory failed: %v", err)
 	}
 	defer f.Close()
+	defer childRoot.Close()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -166,7 +168,7 @@ func TestOpenat_TrailingSlashOnFile(t *testing.T) {
 	_, dirFd := testFS(t, file("file.txt", "content"))
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "file.txt/", false, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "file.txt/", false, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		f.Close()
 		t.Fatal("pathOpen with trailing slash on file should fail")
@@ -178,7 +180,7 @@ func TestOpenat_CreateFile(t *testing.T) {
 	defer dirFd.Close()
 
 	flags := int32(oFlagsCreat)
-	f, err := openat(dirFd, "file.txt", false, flags, 0, uint64(RightsFdWrite))
+	f, _, err := openat(dirFd, "file.txt", false, flags, 0, uint64(RightsFdWrite))
 	if err != nil {
 		t.Fatalf("pathOpen failed: %v", err)
 	}
@@ -194,7 +196,7 @@ func TestOpenat_CreateExclusive(t *testing.T) {
 	defer dirFd.Close()
 
 	flags := int32(oFlagsCreat | oFlagsExcl)
-	f, err := openat(dirFd, "exists.txt", false, flags, 0, uint64(RightsFdWrite))
+	f, _, err := openat(dirFd, "exists.txt", false, flags, 0, uint64(RightsFdWrite))
 	if err == nil {
 		f.Close()
 		t.Fatal("expected error for O_CREAT|O_EXCL on existing file")
@@ -209,7 +211,7 @@ func TestOpenat_Truncate(t *testing.T) {
 	defer dirFd.Close()
 
 	flags := int32(oFlagsTrunc)
-	f, err := openat(dirFd, "trunc.txt", false, flags, 0, uint64(RightsFdWrite))
+	f, _, err := openat(dirFd, "trunc.txt", false, flags, 0, uint64(RightsFdWrite))
 	if err != nil {
 		t.Fatalf("pathOpen failed: %v", err)
 	}
@@ -228,7 +230,7 @@ func TestOpenat_SymlinkEscapeBlocked(t *testing.T) {
 	_, dirFd := testFS(t, link("escape", "/etc"))
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "escape", false, 0, 0, uint64(RightsFdRead))
+	_, _, err := openat(dirFd, "escape", false, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		t.Fatal("expected error when opening symlink with O_NOFOLLOW")
 	}
@@ -241,7 +243,7 @@ func TestOpenat_SymlinkFollowAllowed(t *testing.T) {
 	)
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "link", true, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "link", true, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen with symlink follow failed: %v", err)
 	}
@@ -260,7 +262,7 @@ func TestOpenat_SymlinkFollowEscapeBlocked(t *testing.T) {
 	_, dirFd := testFS(t, link("escape", "/etc/passwd"))
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "escape", true, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "escape", true, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		f.Close()
 		t.Fatal("symlink escape succeeded with SYMLINK_FOLLOW")
@@ -274,7 +276,7 @@ func TestOpenat_SymlinkWithDotDotInsideSandbox(t *testing.T) {
 	)
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "subdir/link", true, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "subdir/link", true, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen failed for symlink with .. inside sandbox: %v", err)
 	}
@@ -296,7 +298,7 @@ func TestOpenat_SymlinkCrossDirectory(t *testing.T) {
 	)
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "a/d/e/link", true, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "a/d/e/link", true, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen failed: %v", err)
 	}
@@ -315,7 +317,7 @@ func TestOpenat_SymlinkWithDotDotEscapeBlocked(t *testing.T) {
 	_, dirFd := testFS(t, link("subdir/link", "../../etc/passwd"))
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "subdir/link", true, 0, 0, uint64(RightsFdRead))
+	_, _, err := openat(dirFd, "subdir/link", true, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		t.Fatal("symlink escape via .. succeeded")
 	}
@@ -325,7 +327,7 @@ func TestOpenat_IntermediateSymlinkBlocked(t *testing.T) {
 	_, dirFd := testFS(t, link("escape_dir", "/etc"))
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "escape_dir/passwd", true, 0, 0, uint64(RightsFdRead))
+	_, _, err := openat(dirFd, "escape_dir/passwd", true, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		t.Fatal("traversing through symlink succeeded")
 	}
@@ -335,9 +337,9 @@ func TestOpenat_DotDotRejected(t *testing.T) {
 	_, dirFd := testFS(t)
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "../etc/passwd", false, 0, 0, uint64(RightsFdRead))
-	if err != syscall.EPERM {
-		t.Errorf("expected syscall.EPERM, got %v", err)
+	_, _, err := openat(dirFd, "../etc/passwd", false, 0, 0, uint64(RightsFdRead))
+	if errno := mapError(err); errno != errnoPerm {
+		t.Errorf("expected errnoPerm, got %d (err %v)", errno, err)
 	}
 }
 
@@ -345,9 +347,9 @@ func TestOpenat_AbsolutePathRejected(t *testing.T) {
 	_, dirFd := testFS(t)
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "/etc/passwd", false, 0, 0, uint64(RightsFdRead))
-	if err != syscall.EPERM {
-		t.Errorf("expected syscall.EPERM, got %v", err)
+	_, _, err := openat(dirFd, "/etc/passwd", false, 0, 0, uint64(RightsFdRead))
+	if errno := mapError(err); errno != errnoPerm {
+		t.Errorf("expected errnoPerm, got %d (err %v)", errno, err)
 	}
 }
 
@@ -355,9 +357,9 @@ func TestOpenat_EmptyPathRejected(t *testing.T) {
 	_, dirFd := testFS(t)
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "", false, 0, 0, uint64(RightsFdRead))
-	if err != syscall.EPERM {
-		t.Errorf("expected syscall.EPERM, got %v", err)
+	_, _, err := openat(dirFd, "", false, 0, 0, uint64(RightsFdRead))
+	if errno := mapError(err); errno != errnoPerm {
+		t.Errorf("expected errnoPerm, got %d (err %v)", errno, err)
 	}
 }
 
@@ -366,7 +368,7 @@ func TestOpenat_AppendFlag(t *testing.T) {
 	defer dirFd.Close()
 
 	flags := int32(fdFlagsAppend)
-	f, err := openat(dirFd, "append.txt", false, 0, flags, uint64(RightsFdWrite))
+	f, _, err := openat(dirFd, "append.txt", false, 0, flags, uint64(RightsFdWrite))
 	if err != nil {
 		t.Fatalf("pathOpen failed: %v", err)
 	}
@@ -388,7 +390,7 @@ func TestOpenat_NonExistent(t *testing.T) {
 	_, dirFd := testFS(t)
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "nonexistent.txt", false, 0, 0, uint64(RightsFdRead))
+	_, _, err := openat(dirFd, "nonexistent.txt", false, 0, 0, uint64(RightsFdRead))
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("expected os.ErrNotExist, got %v", err)
 	}
@@ -399,11 +401,12 @@ func TestOpenat_CurrentDir(t *testing.T) {
 	defer dirFd.Close()
 
 	flags := int32(oFlagsDirectory)
-	f, err := openat(dirFd, ".", false, flags, 0, uint64(RightsFdRead))
+	f, childRoot, err := openat(dirFd, ".", false, flags, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("pathOpen . failed: %v", err)
 	}
 	defer f.Close()
+	defer childRoot.Close()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -640,8 +643,20 @@ func TestStat_DotDotRejected(t *testing.T) {
 	defer dirFd.Close()
 
 	_, err := stat(dirFd, "../etc/passwd", false)
-	if err != syscall.EPERM {
-		t.Errorf("expected syscall.EPERM, got %v", err)
+	if errno := mapError(err); errno != errnoPerm {
+		t.Errorf("expected errnoPerm, got %d (err %v)", errno, err)
+	}
+}
+
+func TestStat_NonLocalLeafEscapeBlocked(t *testing.T) {
+	_, dirFd := testFS(t)
+	defer dirFd.Close()
+
+	for _, name := range []string{"..", "./..", "subdir/../..", "/", "//", ""} {
+		_, err := stat(dirFd, name, false)
+		if errno := mapError(err); errno != errnoPerm {
+			t.Errorf("stat(%q): expected errnoPerm, got %d (err %v)", name, errno, err)
+		}
 	}
 }
 
@@ -650,8 +665,8 @@ func TestStat_AbsolutePathRejected(t *testing.T) {
 	defer dirFd.Close()
 
 	_, err := stat(dirFd, "/etc/passwd", false)
-	if err != syscall.EPERM {
-		t.Errorf("expected syscall.EPERM, got %v", err)
+	if errno := mapError(err); errno != errnoPerm {
+		t.Errorf("expected errnoPerm, got %d (err %v)", errno, err)
 	}
 }
 
@@ -683,8 +698,8 @@ func TestStat_SymlinkChainWithDotDotEscapeBlocked(t *testing.T) {
 	if err == nil {
 		t.Fatal("stat with symlink follow should fail for .. escape")
 	}
-	if !errors.Is(err, syscall.EPERM) {
-		t.Errorf("expected syscall.EPERM, got %v", err)
+	if errno := mapError(err); errno != errnoPerm {
+		t.Errorf("expected errnoPerm, got %d (err %v)", errno, err)
 	}
 }
 
@@ -695,7 +710,7 @@ func TestOpenat_IntermediateSymlinkAllowed(t *testing.T) {
 	)
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "link/file.txt", false, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "link/file.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("openat through intermediate symlink failed: %v", err)
 	}
@@ -718,7 +733,7 @@ func TestOpenat_IntermediateSymlinkWithDotDotAllowed(t *testing.T) {
 	defer dirFd.Close()
 
 	rights := uint64(RightsFdRead)
-	f, err := openat(dirFd, "subdir/link/file.txt", false, 0, 0, rights)
+	f, _, err := openat(dirFd, "subdir/link/file.txt", false, 0, 0, rights)
 	if err != nil {
 		t.Fatalf("openat through symlink with .. failed: %v", err)
 	}
@@ -778,7 +793,7 @@ func TestOpenat_ChainedIntermediateSymlinks(t *testing.T) {
 	)
 	defer dirFd.Close()
 
-	f, err := openat(dirFd, "link2/file.txt", false, 0, 0, uint64(RightsFdRead))
+	f, _, err := openat(dirFd, "link2/file.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
 		t.Fatalf("openat through chained symlinks failed: %v", err)
 	}
@@ -812,7 +827,7 @@ func TestOpenat_PermissionBypass_DotDot(t *testing.T) {
 	// Attempt to open "locked/../target.txt". Traversing "locked" requires +x
 	// permission. Since it is 000, this should fail.
 	rights := uint64(RightsFdRead)
-	f, err := openat(dirFd, "locked/../target.txt", false, 0, 0, rights)
+	f, _, err := openat(dirFd, "locked/../target.txt", false, 0, 0, rights)
 	if err == nil {
 		f.Close()
 		t.Fatal("openat bypassed permission check on 'locked' directory")
@@ -823,7 +838,7 @@ func TestOpenat_IntermediateFileBlocked(t *testing.T) {
 	_, dirFd := testFS(t, file("notadir", "content"))
 	defer dirFd.Close()
 
-	_, err := openat(dirFd, "notadir/file.txt", false, 0, 0, uint64(RightsFdRead))
+	_, _, err := openat(dirFd, "notadir/file.txt", false, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		t.Fatal("traversing through regular file succeeded")
 	}
@@ -839,7 +854,7 @@ func TestOpenat_NonExistent_DotDot(t *testing.T) {
 	// Attempt to open "nonexistent/../target.txt". Should fail because
 	// "nonexistent" does not exist.
 	rights := uint64(RightsFdRead)
-	f, err := openat(dirFd, "nonexistent/../target.txt", false, 0, 0, rights)
+	f, _, err := openat(dirFd, "nonexistent/../target.txt", false, 0, 0, rights)
 	if err == nil {
 		f.Close()
 		t.Fatal("openat bypassed existence check on 'nonexistent' directory")
@@ -860,7 +875,7 @@ func TestOpenat_DotDotEscapeSandboxBlocked(t *testing.T) {
 		t.Fatalf("failed to create sandbox: %v", err)
 	}
 
-	dirFd, err := os.Open(sandboxRoot)
+	dirFd, err := os.OpenRoot(sandboxRoot)
 	if err != nil {
 		t.Fatalf("failed to open sandbox root: %v", err)
 	}
@@ -868,7 +883,7 @@ func TestOpenat_DotDotEscapeSandboxBlocked(t *testing.T) {
 
 	// "subdir/../../outside.txt" should fail (escapes sandbox)
 	rights := uint64(RightsFdRead)
-	f, err := openat(dirFd, "subdir/../../outside.txt", false, 0, 0, rights)
+	f, _, err := openat(dirFd, "subdir/../../outside.txt", false, 0, 0, rights)
 	if err == nil {
 		f.Close()
 		t.Fatal("openat allowed sandbox escape via subdir/../..")
@@ -888,14 +903,14 @@ func TestOpenat_TrailingDotDotBlocked(t *testing.T) {
 		t.Fatalf("failed to create sandbox root: %v", err)
 	}
 
-	dirFd, err := os.Open(sandboxRoot)
+	dirFd, err := os.OpenRoot(sandboxRoot)
 	if err != nil {
 		t.Fatalf("failed to open sandbox root: %v", err)
 	}
 	defer dirFd.Close()
 
 	// Attack: "./.." - trailing .. should fail
-	_, err = openat(dirFd, "./..", false, 0, 0, uint64(RightsFdRead))
+	_, _, err = openat(dirFd, "./..", false, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		t.Fatal("openat allowed escape via ./..")
 	}
@@ -915,14 +930,14 @@ func TestOpenat_SubdirTrailingDotDotBlocked(t *testing.T) {
 		t.Fatalf("failed to create sandbox: %v", err)
 	}
 
-	dirFd, err := os.Open(sandboxRoot)
+	dirFd, err := os.OpenRoot(sandboxRoot)
 	if err != nil {
 		t.Fatalf("failed to open sandbox root: %v", err)
 	}
 	defer dirFd.Close()
 
 	// "subdir/../.." - should fail (escapes sandbox)
-	_, err = openat(dirFd, "subdir/../..", false, 0, 0, uint64(RightsFdRead))
+	_, _, err = openat(dirFd, "subdir/../..", false, 0, 0, uint64(RightsFdRead))
 	if err == nil {
 		t.Fatal("openat allowed escape via subdir/../..")
 	}


### PR DESCRIPTION
Replaces the wasip1 sandbox path resolver with `os.Root` to provide traversal-resistant API.

Gap-handling where os.Root doesn't express exact WASI semantics:
- No-follow open / O_DIRECTORY on a symlink: pre-check with Lstat -> ELOOP.
- Follow-mode stat/utimes/link: gate through os.Root.Stat first so a followed leaf can't escape, then issue one *at syscall.
- unlink/rmdir/rename: resolve the parent via leafParent (OpenRoot(dir) + one *at on the leaf), preserving a trailing slash so the kernel enforces directory semantics.
- mapError matches syscall.Errno before the io/fs sentinels, because e.g. both EEXIST and ENOTEMPTY satisfy fs.ErrExist; it also maps os.Root's *fs.PathError sentinels ("path escapes from parent", "empty path" → errnoPerm).

Passes `make test-all`.

Related to https://github.com/ziggy42/epsilon/issues/75