### PR TITLE
Format Markdown with mdformat and add a fmt-md target

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -33,6 +33,8 @@ adherence to project standards.
    - **If any build fails, stop and report the error.**
 2. **Lint & Format**:
    - Run `make fmt`. If any files are modified, **stop and report the error**.
+   - Run `make fmt-md`. If any files are modified, **stop and report the error**
+     (Markdown is not formatted).
    - Run `make vet`. **If any issues are found, stop and report the error.**
 3. **Run All Tests**:
    - Run `make test` to execute Go tests (unit + spec).

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: code-review
-description:
-  Use this skill when the user asks for a code review. It automates checks and
-  analysis.
+description: Use this skill when the user asks for a code review. It automates checks and analysis.
 ---
 
 # Code Review
@@ -18,151 +16,161 @@ adherence to project standards.
 
 ### 1. Preparation
 
-1.  **Check Branch**: Run `git branch --show-current`. If the output is `main`,
-    inform the user that the current branch is `main` and reviews on `main` are
-    not supported yet.
-2.  **Check Remote**: Run `git fetch origin main`. This ensures `origin/main` is
-    up-to-date for accurate comparison.
-3.  **Get Branch Point**: Determine the merge base with
-    `git merge-base origin/main HEAD`. Store this for later use.
+1. **Check Branch**: Run `git branch --show-current`. If the output is `main`,
+   inform the user that the current branch is `main` and reviews on `main` are
+   not supported yet.
+2. **Check Remote**: Run `git fetch origin main`. This ensures `origin/main` is
+   up-to-date for accurate comparison.
+3. **Get Branch Point**: Determine the merge base with
+   `git merge-base origin/main HEAD`. Store this for later use.
 
 ### 2. Build & Test Verification
 
-1.  **Build for All Platforms**:
-    - Run `make build-all` (covers Linux, Darwin, and Windows cross-compile,
-      regardless of host OS).
-    - Cleanup afterwards: `make clean`.
-    - **If any build fails, stop and report the error.**
-2.  **Lint & Format**:
-    - Run `make fmt`. If any files are modified, **stop and report the error**.
-    - Run `make vet`. **If any issues are found, stop and report the error.**
-3.  **Run All Tests**:
-    - Run `make test` to execute Go tests (unit + spec).
-    - **If tests fail, stop and report the errors.**
-4.  **Run WASI Tests**:
-    - Run `make test-wasi` to verify the WASI Preview 1 implementation.
-    - **If WASI tests fail, stop and report the errors.**
+1. **Build for All Platforms**:
+   - Run `make build-all` (covers Linux, Darwin, and Windows cross-compile,
+     regardless of host OS).
+   - Cleanup afterwards: `make clean`.
+   - **If any build fails, stop and report the error.**
+2. **Lint & Format**:
+   - Run `make fmt`. If any files are modified, **stop and report the error**.
+   - Run `make vet`. **If any issues are found, stop and report the error.**
+3. **Run All Tests**:
+   - Run `make test` to execute Go tests (unit + spec).
+   - **If tests fail, stop and report the errors.**
+4. **Run WASI Tests**:
+   - Run `make test-wasi` to verify the WASI Preview 1 implementation.
+   - **If WASI tests fail, stop and report the errors.**
 
 ### 3. Performance Verification
 
-1.  **Compare Benchmarks**: Run `make bench-compare TARGET=.` to compare
-    performance against the `main` branch (the default base). **NOTE**: This
-    can take several minutes as it runs the benchmark suite twice.
-2.  **Review Results**: Present the benchmark results to the user. Flag any
-    regressions where:
-    - Time (ns/op) increased by more than 5%.
-    - Memory (B/op) increased.
-    - Allocations (allocs/op) increased.
+1. **Compare Benchmarks**: Run `make bench-compare TARGET=.` to compare
+   performance against the `main` branch (the default base). **NOTE**: This can
+   take several minutes as it runs the benchmark suite twice.
+2. **Review Results**: Present the benchmark results to the user. Flag any
+   regressions where:
+   - Time (ns/op) increased by more than 5%.
+   - Memory (B/op) increased.
+   - Allocations (allocs/op) increased.
 
 ### 4. Dependency Check
 
-1.  **Detect New Dependencies**: Run
-    `git diff origin/main..HEAD -- go.mod go.sum`.
-2.  **Verify Module Consistency**:
-    - Run `go mod tidy`.
-    - Run `git diff --name-only go.mod go.sum`.
-    - If there are changes, **stop and report that `go mod tidy` needs to be
-      run**.
-3.  **Report Changes**: If there are any changes to `go.mod` or `go.sum`:
-    - **CRITICAL**: This project is **pure Go with no CGo**. New dependencies
-      are strongly discouraged.
-    - Report exactly what dependencies were added or modified.
-    - Ask the user to confirm the dependency changes are intentional.
+1. **Detect New Dependencies**: Run
+   `git diff origin/main..HEAD -- go.mod go.sum`.
+2. **Verify Module Consistency**:
+   - Run `go mod tidy`.
+   - Run `git diff --name-only go.mod go.sum`.
+   - If there are changes, **stop and report that `go mod tidy` needs to be
+     run**.
+3. **Report Changes**: If there are any changes to `go.mod` or `go.sum`:
+   - **CRITICAL**: This project is **pure Go with no CGo**. New dependencies are
+     strongly discouraged.
+   - Report exactly what dependencies were added or modified.
+   - Ask the user to confirm the dependency changes are intentional.
 
 ### 5. License Header Check
 
-1.  **Find New Files**: Run
-    `git diff --name-status origin/main..HEAD | grep '^A'` to list all newly
-    added files.
-2.  **Check Headers**: For each new source file (`.go`, `.py`, `.yml`, etc.),
-    verify it contains the proper license header:
+1. **Find New Files**: Run
+   `git diff --name-status origin/main..HEAD | grep '^A'` to list all newly
+   added files.
 
-    ```
-    // Copyright [Year] Google LLC
-    //
-    // Licensed under the Apache License, Version 2.0 (the "License");
-    // you may not use this file except in compliance with the License.
-    // You may obtain a copy of the License at
-    //
-    //     http://www.apache.org/licenses/LICENSE-2.0
-    //
-    // Unless required by applicable law or agreed to in writing, software
-    // distributed under the License is distributed on an "AS IS" BASIS,
-    // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    // See the License for the specific language governing permissions and
-    // limitations under the License.
-    ```
+2. **Check Headers**: For each new source file (`.go`, `.py`, `.yml`, etc.),
+   verify it contains the proper license header:
 
-    Use the appropriate comment syntax for the file type (e.g., `#` for Python
-    and YAML).
+   ```
+   // Copyright [Year] Google LLC
+   //
+   // Licensed under the Apache License, Version 2.0 (the "License");
+   // you may not use this file except in compliance with the License.
+   // You may obtain a copy of the License at
+   //
+   //     http://www.apache.org/licenses/LICENSE-2.0
+   //
+   // Unless required by applicable law or agreed to in writing, software
+   // distributed under the License is distributed on an "AS IS" BASIS,
+   // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   // See the License for the specific language governing permissions and
+   // limitations under the License.
+   ```
 
-3.  **Report Missing Headers**: List any files missing the license header.
+   Use the appropriate comment syntax for the file type (e.g., `#` for Python
+   and YAML).
+
+3. **Report Missing Headers**: List any files missing the license header.
 
 ### 6. Code Review
 
-1.  **Get the Diff**: Run `git diff origin/main..HEAD` to see all changes.
-2.  **Review for Issues**: Analyze the diff and check for:
+1. **Get the Diff**: Run `git diff origin/main..HEAD` to see all changes.
 
-    **Bugs & Correctness**:
-    - Logic errors and edge cases.
-    - Improper error handling (errors must be handled or propagated, never
-      ignored).
-    - Data races or concurrency issues.
-    - Off-by-one errors.
+2. **Review for Issues**: Analyze the diff and check for:
 
-    **Security & Sandboxing**: Treat untrusted Wasm and host inputs as hostile.
-    The bullets below are a floor, not a ceiling — hunt for classes of flaw they
-    don't name.
-    - Validator is the boundary: the VM trusts it, so any skipped or weakened
-      check there is exploitable.
-    - Untrusted Wasm or invalid host inputs must never panic — failures surface
-      as standard Go errors.
-    - Sandbox escapes: untrusted code reaching host state it shouldn't see.
+   **Bugs & Correctness**:
 
-    **Performance** (especially in hot paths like the VM loop):
-    - Unnecessary heap allocations.
-    - Inefficient algorithms.
-    - Missed opportunities to reuse buffers/slices.
-    - Unnecessary copying of data.
+   - Logic errors and edge cases.
+   - Improper error handling (errors must be handled or propagated, never
+     ignored).
+   - Data races or concurrency issues.
+   - Off-by-one errors.
 
-    **Simplicity & Readability**:
-    - Overly complex code that could be simplified.
-    - Duplicate code that could be refactored.
-    - Poor variable naming (names should be self-explanatory).
-    - Unnecessary comments (code should be self-explanatory). Verify no "TODO",
-      "FIXME", or placeholder comments were left behind.
+   **Security & Sandboxing**: Treat untrusted Wasm and host inputs as hostile.
+   The bullets below are a floor, not a ceiling — hunt for classes of flaw they
+   don't name.
 
-    **Documentation**:
-    - Ensure `README.md` and other documentation is updated if new features,
-      flags, or configuration options were added.
-    - Ensure `AGENTS.md` is still accurate after the change: if the diff alters
-      the project layout, build/test commands, conventions, or constraints it
-      documents, it must be updated to match.
+   - Validator is the boundary: the VM trusts it, so any skipped or weakened
+     check there is exploitable.
+   - Untrusted Wasm or invalid host inputs must never panic — failures surface
+     as standard Go errors.
+   - Sandbox escapes: untrusted code reaching host state it shouldn't see.
 
-    **Modern Go Features**:
-    - Opportunities to use newer Go features (e.g., generics, improved slices
-      package, range-over-int, etc.).
-    - Deprecated patterns that should be updated.
+   **Performance** (especially in hot paths like the VM loop):
 
-    **Project Standards**:
-    - Adherence to rules in `AGENTS.md`.
-    - Consistent style with existing code.
+   - Unnecessary heap allocations.
+   - Inefficient algorithms.
+   - Missed opportunities to reuse buffers/slices.
+   - Unnecessary copying of data.
 
-3.  **Compile Findings**: Create a structured report with:
-    - **Critical Issues**: Bugs, correctness problems, or security concerns that
-      must be fixed.
-    - **Suggestions**: Performance improvements, simplifications, or style
-      enhancements.
-    - **Notes**: Minor observations or questions.
+   **Simplicity & Readability**:
+
+   - Overly complex code that could be simplified.
+   - Duplicate code that could be refactored.
+   - Poor variable naming (names should be self-explanatory).
+   - Unnecessary comments (code should be self-explanatory). Verify no "TODO",
+     "FIXME", or placeholder comments were left behind.
+
+   **Documentation**:
+
+   - Ensure `README.md` and other documentation is updated if new features,
+     flags, or configuration options were added.
+   - Ensure `AGENTS.md` is still accurate after the change: if the diff alters
+     the project layout, build/test commands, conventions, or constraints it
+     documents, it must be updated to match.
+
+   **Modern Go Features**:
+
+   - Opportunities to use newer Go features (e.g., generics, improved slices
+     package, range-over-int, etc.).
+   - Deprecated patterns that should be updated.
+
+   **Project Standards**:
+
+   - Adherence to rules in `AGENTS.md`.
+   - Consistent style with existing code.
+
+3. **Compile Findings**: Create a structured report with:
+
+   - **Critical Issues**: Bugs, correctness problems, or security concerns that
+     must be fixed.
+   - **Suggestions**: Performance improvements, simplifications, or style
+     enhancements.
+   - **Notes**: Minor observations or questions.
 
 ### 7. Report
 
 Present a summary to the user containing:
 
-1.  ✅ or ❌ for each verification step (build, lint, tests, spec tests, WASI
-    tests).
-2.  Benchmark comparison results with any regressions highlighted.
-3.  Dependency change report (if any).
-4.  List of files missing license headers (if any).
-5.  Code review findings organized by severity.
-6.  An overall recommendation: **Ready to Merge** or **Needs Changes**.
+1. ✅ or ❌ for each verification step (build, lint, tests, spec tests, WASI
+   tests).
+2. Benchmark comparison results with any regressions highlighted.
+3. Dependency change report (if any).
+4. List of files missing license headers (if any).
+5. Code review findings organized by severity.
+6. An overall recommendation: **Ready to Merge** or **Needs Changes**.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -15,96 +15,104 @@ updates, and git tagging.
 
 ### 1. Preparation & Version Determination
 
-1.  **Check Branch**: Run `git branch --show-current`. If the output is not
-    `main`, stop and inform the user that releases must be cut from the `main`
-    branch.
-2.  **Sync with Remote**: Run `git fetch origin main`. Then verify local is
-    up-to-date by running `git rev-list HEAD..origin/main --count`. If the count
-    is non-zero, stop and inform the user that their local `main` is behind
-    `origin/main` and they need to pull first.
-3.  **Check Working Tree**: Run `git status --porcelain`.
-    - **CRITICAL**: If the command produces **ANY** output (even for untracked
-      files or documentation changes), you **MUST ABORT IMMEDIATELY**.
-    - **DO NOT** attempt to analyze the changes.
-    - **DO NOT** ask the user if they want to proceed.
-    - **STOP** and inform the user: "Working tree is not clean. Please commit or
-      stash changes before releasing."
-4.  **Check Current Version**: Read `epsilon/version.go` to find the current
-    version (e.g., "0.0.3").
-5.  **Determine Target Version**:
-    - **User Provided**: If the user specified a version, validate it. It must
-      be semantically greater than the current version. If invalid, reject it
-      and explain why.
-    - **Auto-Increment**: If no version was provided, increment the **patch**
-      level of the current version (e.g., 0.0.3 -> 0.0.4).
-6.  **Confirm**: Briefly mention the plan to the user (e.g., "Preparing release
-    for v0.0.4...").
+1. **Check Branch**: Run `git branch --show-current`. If the output is not
+   `main`, stop and inform the user that releases must be cut from the `main`
+   branch.
+2. **Sync with Remote**: Run `git fetch origin main`. Then verify local is
+   up-to-date by running `git rev-list HEAD..origin/main --count`. If the count
+   is non-zero, stop and inform the user that their local `main` is behind
+   `origin/main` and they need to pull first.
+3. **Check Working Tree**: Run `git status --porcelain`.
+   - **CRITICAL**: If the command produces **ANY** output (even for untracked
+     files or documentation changes), you **MUST ABORT IMMEDIATELY**.
+   - **DO NOT** attempt to analyze the changes.
+   - **DO NOT** ask the user if they want to proceed.
+   - **STOP** and inform the user: "Working tree is not clean. Please commit or
+     stash changes before releasing."
+4. **Check Current Version**: Read `epsilon/version.go` to find the current
+   version (e.g., "0.0.3").
+5. **Determine Target Version**:
+   - **User Provided**: If the user specified a version, validate it. It must be
+     semantically greater than the current version. If invalid, reject it and
+     explain why.
+   - **Auto-Increment**: If no version was provided, increment the **patch**
+     level of the current version (e.g., 0.0.3 -> 0.0.4).
+6. **Confirm**: Briefly mention the plan to the user (e.g., "Preparing release
+   for v0.0.4...").
 
 ### 2. Verification
 
-1.  **Build**: Run `make build-all` (native + Darwin + Windows cross-compile).
-    If any build fails, stop and report the error.
-2.  **Run Tests**: Run `make test`. If tests fail, stop and report the
-    errors.
-3.  **Compare Benchmarks**: Find the previous release tag using
-    `git describe --tags --abbrev=0`. Then run
-    `make bench-compare TARGET=. BASE=<last_tag>` to compare performance
-    against the last release. Present the results to the user and flag any
-    significant regressions. **NOTE**: This process can take several minutes
-    as it runs the full benchmark suite twice; ensure a reasonable timeout
-    (e.g., 10m) is applied.
+1. **Build**: Run `make build-all` (native + Darwin + Windows cross-compile). If
+   any build fails, stop and report the error.
+2. **Run Tests**: Run `make test`. If tests fail, stop and report the errors.
+3. **Compare Benchmarks**: Find the previous release tag using
+   `git describe --tags --abbrev=0`. Then run
+   `make bench-compare TARGET=. BASE=<last_tag>` to compare performance against
+   the last release. Present the results to the user and flag any significant
+   regressions. **NOTE**: This process can take several minutes as it runs the
+   full benchmark suite twice; ensure a reasonable timeout (e.g., 10m) is
+   applied.
 
 ### 3. Changelog Generation
 
 **Only proceed if verification passes.**
 
-1.  **Identify Range**: Find the previous release tag using
-    `git describe --tags --abbrev=0`.
-2.  **Fetch Commits**: Run
-    `git log --no-merges --pretty=format:"%h %s%n%b" <last_tag>..HEAD`.
-3.  **Draft Content**: Analyze the commit messages (subject and body) to create
-    a new CHANGELOG entry.
-    - **Deep Inspection**: Look at the commit **body** for additional context.
-      Squashed PRs often include a detailed list of changes, bullet points, or
-      rationale in the description. Use this to create a more informative
-      summary.
-    - **Audience**: The changelog is for **end users**. Focus on changes that
-      affect how users interact with the project.
-    - **Style**: Mimic the existing style in `CHANGELOG.md`.
-    - **Filtering**: Include only changes that matter to users: new features,
-      bug fixes, API changes. Exclude chores, typos, refactoring, CI tweaks, and
-      internal tooling changes.
-    - **Grouping**: Group by category if appropriate (e.g., API Changes,
-      Performance, Fixes).
-    - **Breaking Changes**: Explicitly highlight any breaking changes.
-    - **Format**:
+1. **Identify Range**: Find the previous release tag using
+   `git describe --tags --abbrev=0`.
 
-      ```markdown
-      ## [Version] - YYYY-MM-DD
+2. **Fetch Commits**: Run
+   `git log --no-merges --pretty=format:"%h %s%n%b" <last_tag>..HEAD`.
 
-      - Description of change (#PR or commit hash if available).
-      - ...
-      ```
+3. **Draft Content**: Analyze the commit messages (subject and body) to create a
+   new CHANGELOG entry.
 
-4.  **Review**: Present the drafted CHANGELOG entry to the user and ask for
-    confirmation. **Do not proceed without user approval.**
+   - **Deep Inspection**: Look at the commit **body** for additional context.
+     Squashed PRs often include a detailed list of changes, bullet points, or
+     rationale in the description. Use this to create a more informative
+     summary.
+
+   - **Audience**: The changelog is for **end users**. Focus on changes that
+     affect how users interact with the project.
+
+   - **Style**: Mimic the existing style in `CHANGELOG.md`.
+
+   - **Filtering**: Include only changes that matter to users: new features, bug
+     fixes, API changes. Exclude chores, typos, refactoring, CI tweaks, and
+     internal tooling changes.
+
+   - **Grouping**: Group by category if appropriate (e.g., API Changes,
+     Performance, Fixes).
+
+   - **Breaking Changes**: Explicitly highlight any breaking changes.
+
+   - **Format**:
+
+     ```markdown
+     ## [Version] - YYYY-MM-DD
+
+     - Description of change (#PR or commit hash if available).
+     - ...
+     ```
+
+4. **Review**: Present the drafted CHANGELOG entry to the user and ask for
+   confirmation. **Do not proceed without user approval.**
 
 ### 4. Execution
 
 **Only proceed after User Confirmation of the changelog.**
 
-1.  **Update CHANGELOG.md**:
-    - Read `CHANGELOG.md`.
-    - Insert the new entry at the top of the changelog (after the header
-      section).
-    - Write the file.
-2.  **Update Version**:
-    - Update `epsilon/version.go` with the new version string.
-3.  **Commit & Tag**:
-    - Run `git add CHANGELOG.md epsilon/version.go`.
-    - Run `git commit -m "Release version <Version>"`.
-    - Run `git tag v<Version>`.
-4.  **Push**:
-    - Run `git push origin main --tags`.
-5.  **Finalize**:
-    - Inform the user the release is committed, tagged, and pushed.
+1. **Update CHANGELOG.md**:
+   - Read `CHANGELOG.md`.
+   - Insert the new entry at the top of the changelog (after the header
+     section).
+   - Write the file.
+2. **Update Version**:
+   - Update `epsilon/version.go` with the new version string.
+3. **Commit & Tag**:
+   - Run `git add CHANGELOG.md epsilon/version.go`.
+   - Run `git commit -m "Release version <Version>"`.
+   - Run `git tag v<Version>`.
+4. **Push**:
+   - Run `git push origin main --tags`.
+5. **Finalize**:
+   - Inform the user the release is committed, tagged, and pushed.

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: security-audit
-description:
-  Use this skill to perform a security-focused audit of the codebase to identify
-  vulnerabilities, sandbox escapes, and logic flaws.
+description: Use this skill to perform a security-focused audit of the codebase to identify vulnerabilities, sandbox escapes, and logic flaws.
 ---
 
 # Security Audit
@@ -22,35 +20,35 @@ Your goal is to find flaws that automated tools or basic reviews miss. Do not
 restrict yourself to a predefined checklist. Instead, employ a systematic,
 deep-dive methodology:
 
-1.  **Select Entry Points**: Begin at the boundaries where untrusted input
-    enters the system or interacts with the host. High-value starting points
-    include the main execution loop (e.g., `epsilon/vm.go`), host interface
-    boundaries (e.g., `wasip1/`), or memory indexing operations.
-2.  **Spawn Specialized Subagents**: For complex files or distinct components,
-    spawn focused subagents to audit them in isolation. Instruct these subagents
-    to investigate specific mechanics deeply rather than doing a shallow read.
-3.  **Trace Execution Paths**: Follow the flow of untrusted data (instructions,
-    indices, offsets, file descriptors) from ingestion to execution. Assume the
-    input is malicious.
-4.  **Audit Specification Deviations**: Compare the implementation of complex
-    instructions against the WebAssembly 2.0 formal execution rules. Any
-    optimization that skips or defers a spec-mandated check is a potential
-    vulnerability.
+1. **Select Entry Points**: Begin at the boundaries where untrusted input enters
+   the system or interacts with the host. High-value starting points include the
+   main execution loop (e.g., `epsilon/vm.go`), host interface boundaries (e.g.,
+   `wasip1/`), or memory indexing operations.
+2. **Spawn Specialized Subagents**: For complex files or distinct components,
+   spawn focused subagents to audit them in isolation. Instruct these subagents
+   to investigate specific mechanics deeply rather than doing a shallow read.
+3. **Trace Execution Paths**: Follow the flow of untrusted data (instructions,
+   indices, offsets, file descriptors) from ingestion to execution. Assume the
+   input is malicious.
+4. **Audit Specification Deviations**: Compare the implementation of complex
+   instructions against the WebAssembly 2.0 formal execution rules. Any
+   optimization that skips or defers a spec-mandated check is a potential
+   vulnerability.
 
 ### 2. Verification & PoC Generation
 
 **Never report a bug without actively triggering it locally.**
 
-1.  **Create a Vulnerability Directory**: For each confirmed flaw, create a new
-    directory at `vulnerabilities/[id]/` (e.g., `vulnerabilities/VULN-01/`).
-2.  **Write the PoC**: Place a Go test or a minimal `.wasm` file that reliably
-    triggers the flaw inside the specific vulnerability directory.
-3.  **Test Constraints**:
-    - Do NOT write tests that invoke a single VM instance concurrently.
-    - To prove state leakage, write tests that run multiple independent VMs
-      concurrently using `go test -race`.
-    - To prove parser crashes or bounds-check failures, write a standard Go fuzz
-      test (`go test -fuzz`).
+1. **Create a Vulnerability Directory**: For each confirmed flaw, create a new
+   directory at `vulnerabilities/[id]/` (e.g., `vulnerabilities/VULN-01/`).
+2. **Write the PoC**: Place a Go test or a minimal `.wasm` file that reliably
+   triggers the flaw inside the specific vulnerability directory.
+3. **Test Constraints**:
+   - Do NOT write tests that invoke a single VM instance concurrently.
+   - To prove state leakage, write tests that run multiple independent VMs
+     concurrently using `go test -race`.
+   - To prove parser crashes or bounds-check failures, write a standard Go fuzz
+     test (`go test -fuzz`).
 
 ### 3. Reporting Format
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,6 +33,13 @@ jobs:
         go-version-file: 'go.mod'
     - name: Set up uv
       uses: astral-sh/setup-uv@v5
+    - name: Format check
+      run: |
+        make fmt fmt-md
+        git diff --exit-code \
+          || { echo "::error::Run 'make fmt' and 'make fmt-md', then commit the result."; exit 1; }
+    - name: Vet
+      run: make vet
     - name: Build
       run: make build-all
     - name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ library and as a CLI. Layout:
 
 - **Build & test**: The root `Makefile` is the entry point (`make help` lists
   all targets). Before considering a change complete, run `make fmt`,
-  `make vet`, and `make test-all` and make sure they pass.
+  `make vet`, and `make test-all` and make sure they pass; if you changed
+  Markdown, also run `make fmt-md`.
 - **Performance**:
   - Minimize heap allocations in the hot path (VM instruction loop).
   - Prefer reusing buffers/slices where possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to this project will be documented in this file.
 
 This release fixes a significant number of security and correctness issues
 throughout the runtime. Background on several of the vulnerabilities is
-available in this [article](https://andreapivetta.com/posts/all-the-bugs-they-found.html).
-Overall performance is roughly unchanged from 0.0.4; one microbenchmark
-exercising `call_indirect` is about 10% slower due to the additional safety
-checks.
+available in this
+[article](https://andreapivetta.com/posts/all-the-bugs-they-found.html). Overall
+performance is roughly unchanged from 0.0.4; one microbenchmark exercising
+`call_indirect` is about 10% slower due to the additional safety checks.
 
 ### New Features
 
@@ -51,6 +51,7 @@ checks.
   ```
 
 - `Default*` constants are exposed for every non-zero `Config` default (#67).
+
 - REPL removed (#38).
 
 ### Security & Correctness Fixes
@@ -92,14 +93,19 @@ checks.
 
 ## [0.0.4] - 2026-02-01
 
-- Added experimental support for [WASI Preview 1](wasip1/README.md) on Linux and macOS.
-- **API Changes**: Host functions now receive `ModuleInstance` as their first argument, enabling context-aware implementations (#32).
+- Added experimental support for [WASI Preview 1](wasip1/README.md) on Linux and
+  macOS.
+- **API Changes**: Host functions now receive `ModuleInstance` as their first
+  argument, enabling context-aware implementations (#32).
 - CLI now invokes `_start` by default if no entry point is specified.
 
 ## [0.0.3] - 2025-12-20
 
-- **API Changes**: `ExperimentalFeatures` has been replaced by `Config`, and `Runtime.WithFeatures` has been renamed to `WithConfig` (#28).
-- `Config` now allows configuring pre-allocated cache sizes and the maximum call stack depth. It also retains support for enabling experimental features like `ExperimentalMultipleMemories` (#28).
+- **API Changes**: `ExperimentalFeatures` has been replaced by `Config`, and
+  `Runtime.WithFeatures` has been renamed to `WithConfig` (#28).
+- `Config` now allows configuring pre-allocated cache sizes and the maximum call
+  stack depth. It also retains support for enabling experimental features like
+  `ExperimentalMultipleMemories` (#28).
 - Major performance improvements (#25, #28, #30).
 
 ## [0.0.2] - 2025-12-14

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,11 @@ run-example: ## Run the basic example (smoke check)
 fmt: ## Run gofmt across the tree
 	go fmt ./...
 
+fmt-md: ## Format repo-owned Markdown
+	git ls-files -z '*.md' ':!:CONTRIBUTING.md' ':!:CLAUDE.md' | \
+		xargs -0 uvx --with mdformat-gfm --with mdformat-frontmatter \
+		mdformat --wrap 80 --number
+
 vet: ## Run go vet across the tree
 	go vet ./...
 
@@ -202,6 +207,6 @@ internal/spec_tests/testsuite/.git wasip1/wasi-testsuite/.git:
 
 # ----- phony declarations -----------------------------------------------------
 
-.PHONY: help build build-all run-example fmt vet clean distclean \
+.PHONY: help build build-all run-example fmt fmt-md vet clean distclean \
         test test-spec test-wasi test-all bench bench-compare \
         build-wasm setup-wasi-sdk setup-wabt

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,11 @@ run-example: ## Run the basic example (smoke check)
 fmt: ## Run gofmt across the tree
 	go fmt ./...
 
-fmt-md: ## Format repo-owned Markdown
+fmt-md: check-uv ## Format repo-owned Markdown
 	git ls-files -z '*.md' ':!:CONTRIBUTING.md' ':!:CLAUDE.md' | \
-		xargs -0 uvx --with mdformat-gfm --with mdformat-frontmatter \
-		mdformat --wrap 80 --number
+		xargs -0 uvx \
+		--with mdformat-gfm==1.0.0 --with mdformat-frontmatter==2.1.2 \
+		mdformat@1.0.0 --wrap 80 --number
 
 vet: ## Run go vet across the tree
 	go vet ./...
@@ -125,13 +126,17 @@ test: setup-wabt ## Run all Go tests (unit + spec)
 test-spec: internal/spec_tests/testsuite/.git setup-wabt ## Run wasm spec tests
 	go test ./internal/spec_tests/...
 
-test-wasi: wasip1/wasi-testsuite/.git ## Run the WASI testsuite (needs uv)
+test-wasi: wasip1/wasi-testsuite/.git check-uv ## Run the WASI testsuite
+	uv run --with-requirements requirements.txt wasip1/wasi_testsuite.py
+
+# Internal helper (no ## so it stays out of `make help`): a prerequisite for
+# targets that shell out to uv/uvx.
+check-uv:
 	@command -v uv >/dev/null 2>&1 || { \
 	  echo "Error: 'uv' is not installed." && \
 	  echo "See https://docs.astral.sh/uv/ for instructions." && \
 	  exit 1; \
 	}
-	uv run --with-requirements requirements.txt wasip1/wasi_testsuite.py
 
 test-all: test test-wasi ## Run all tests (Go tests + WASI spec tests)
 
@@ -207,6 +212,6 @@ internal/spec_tests/testsuite/.git wasip1/wasi-testsuite/.git:
 
 # ----- phony declarations -----------------------------------------------------
 
-.PHONY: help build build-all run-example fmt fmt-md vet clean distclean \
-        test test-spec test-wasi test-all bench bench-compare \
+.PHONY: help build build-all run-example fmt fmt-md check-uv vet clean \
+        distclean test test-spec test-wasi test-all bench bench-compare \
         build-wasm setup-wasi-sdk setup-wabt

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ $(WASM_OUT_DIR):
 
 # $(1) = archive basename, $(2) = URL, $(3) = dest dir,
 # $(4) = directory name inside the extracted tarball.
-# $(strip ...) absorbs whitespace introduced by `\` line continuation at
-# the call site.
+# $(strip ...) absorbs whitespace introduced by `\` line continuation at the
+# call site.
 define install-toolchain
 	$(eval N := $(strip $(1)))
 	$(eval U := $(strip $(2)))

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/ziggy42/epsilon)](https://github.com/ziggy42/epsilon/blob/main/go.mod)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**Epsilon** is a pure Go WebAssembly runtime with zero dependencies. 
+**Epsilon** is a pure Go WebAssembly runtime with zero dependencies.
 
-* Fully supports [WebAssembly 2.0 Specification](https://webassembly.github.io/spec/versions/core/WebAssembly-2.0.pdf)
-* Runs on any architecture supported by Go (amd64, arm64, etc.) without requiring CGo
-* Allows embedding WebAssembly modules in Go applications
-* Includes experimental [WASI Preview 1](wasip1/README.md) support
-* Includes a command-line interface
+- Fully supports
+  [WebAssembly 2.0 Specification](https://webassembly.github.io/spec/versions/core/WebAssembly-2.0.pdf)
+- Runs on any architecture supported by Go (amd64, arm64, etc.) without
+  requiring CGo
+- Allows embedding WebAssembly modules in Go applications
+- Includes experimental [WASI Preview 1](wasip1/README.md) support
+- Includes a command-line interface
 
 ## Installation
 
@@ -64,7 +66,7 @@ func main() {
 
 ### Using Host Functions
 
-Extend your WebAssembly modules with custom Go functions and more using 
+Extend your WebAssembly modules with custom Go functions and more using
 `ModuleImports`:
 
 ```go
@@ -116,7 +118,8 @@ $ epsilon https://github.com/mdn/webassembly-examples/raw/refs/heads/main/unders
 
 ## Development
 
-A complete set of development targets is defined in the `Makefile`. Run `make` (or `make help`) to view the available targets:
+A complete set of development targets is defined in the `Makefile`. Run `make`
+(or `make help`) to view the available targets:
 
 ```text
 Usage: make <target>
@@ -147,10 +150,9 @@ Common overrides:
   WASI_SDK_DIR=<p>      wasi-sdk path (default: .toolchain/wasi-sdk)
 ```
 
-Targets that need external toolchains (`wasi-sdk` for `build-wasm`, `wabt`
-for the spec tests) auto-install them into `.toolchain/` on first run.
-`test-wasi` additionally needs [`uv`](https://docs.astral.sh/uv/) installed
-on the host.
+Targets that need external toolchains (`wasi-sdk` for `build-wasm`, `wabt` for
+the spec tests) auto-install them into `.toolchain/` on first run. `test-wasi`
+additionally needs [`uv`](https://docs.astral.sh/uv/) installed on the host.
 
 ## Contributing
 
@@ -162,6 +164,6 @@ Apache 2.0; see [`LICENSE`](LICENSE) for details.
 
 ## Disclaimer
 
-This is not an officially supported Google product. This project is not
-eligible for the [Google Open Source Software Vulnerability Rewards
-Program](https://bughunters.google.com/open-source-security).
+This is not an officially supported Google product. This project is not eligible
+for the
+[Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).

--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ Targets:
   build-all             Cross-compile the CLI for Linux, Darwin, and Windows
   run-example           Run the basic example (smoke check)
   fmt                   Run gofmt across the tree
+  fmt-md                Format repo-owned Markdown
   vet                   Run go vet across the tree
   clean                 Remove built artifacts (keeps the wasi-sdk toolchain)
   distclean             Remove built artifacts AND the wasi-sdk toolchain
   test                  Run all Go tests (unit + spec)
   test-spec             Run wasm spec tests
-  test-wasi             Run the WASI testsuite (needs uv)
+  test-wasi             Run the WASI testsuite
   test-all              Run all tests (Go tests + WASI spec tests)
   bench                 Run benchmarks (vars: BENCH_PATTERN, etc.)
   bench-compare         Compare benchmarks across refs; TARGET=<ref> required

--- a/wasip1/README.md
+++ b/wasip1/README.md
@@ -1,17 +1,18 @@
 # WASI Preview 1 Implementation
 
-This package provides a [WASI Preview 1](https://github.com/WebAssembly/WASI/blob/8d7fb6eff7d5964b2375beb10518d2327a1dcfe8/legacy/README.md) 
+This package provides a
+[WASI Preview 1](https://github.com/WebAssembly/WASI/blob/8d7fb6eff7d5964b2375beb10518d2327a1dcfe8/legacy/README.md)
 (`wasi_snapshot_preview1`) implementation for the Epsilon WebAssembly runtime.
 
 > **Note**: This implementation is experimental, use at your own risk.
 
 ## Platform Support
 
-| Platform | Status |
-|----------|--------|
-| Linux | ✅ Supported |
-| macOS | ✅ Supported |
-| Windows | ❌ Not Supported |
+| Platform | Status           |
+| -------- | ---------------- |
+| Linux    | ✅ Supported     |
+| macOS    | ✅ Supported     |
+| Windows  | ❌ Not Supported |
 
 On non-Unix platforms, `NewWasiModuleBuilder().Build()` returns an error.
 
@@ -60,7 +61,6 @@ func main() {
 }
 ```
 
-
 ## Testing
 
 This implementation is tested against the official
@@ -68,8 +68,8 @@ This implementation is tested against the official
 
 ### Prerequisites
 
-- **[uv](https://docs.astral.sh/uv/)**: Python package manager for running the 
-	test runner
+- **[uv](https://docs.astral.sh/uv/)**: Python package manager for running the
+  test runner
 
 ### Running WASI Spec Tests
 
@@ -86,22 +86,22 @@ limitations:
 
 ### Clocks
 
-- **`clock_time_get`**: The `process_cputime_id` and `thread_cputime_id` clocks 
+- **`clock_time_get`**: The `process_cputime_id` and `thread_cputime_id` clocks
   return `ERRNO_NOTSUP`. Only `realtime` and `monotonic` are supported.
 
 ### Signals
 
-- **`proc_raise`**: Always returns `ERRNO_NOTSUP`. Signal handling is not 
-	implemented.
+- **`proc_raise`**: Always returns `ERRNO_NOTSUP`. Signal handling is not
+  implemented.
 
 ### Sockets
 
-Socket operations work with pre-opened socket file descriptors but have the 
+Socket operations work with pre-opened socket file descriptors but have the
 following limitations:
 
-- **No socket creation**: There is no way to create new sockets from WASM.
-  The host must pre-open a listening socket and pass it to the WASM module.
-- **`sock_recv`**: The `ri_flags` parameter (e.g., `MSG_PEEK`, `MSG_WAITALL`) is 
+- **No socket creation**: There is no way to create new sockets from WASM. The
+  host must pre-open a listening socket and pass it to the WASM module.
+- **`sock_recv`**: The `ri_flags` parameter (e.g., `MSG_PEEK`, `MSG_WAITALL`) is
   ignored. Receive always uses standard blocking read semantics.
 - **`sock_send`**: The `si_flags` parameter (e.g., `MSG_OOB`) is ignored.
 
@@ -111,5 +111,5 @@ following limitations:
   (`select`/`poll`/`epoll`). All file descriptors — including sockets — are
   always reported as immediately ready regardless of actual I/O readiness.
   Modules that poll a socket waiting for data will busy-loop with no sleep,
-  causing 100% CPU usage. Clock subscriptions use `time.Sleep`. Hangup
-  detection (`FD_READWRITE_HANGUP`) for sockets is not implemented.
+  causing 100% CPU usage. Clock subscriptions use `time.Sleep`. Hangup detection
+  (`FD_READWRITE_HANGUP`) for sockets is not implemented.


### PR DESCRIPTION
Adds a `make fmt-md` target that formats the repo's own Markdown to an
80-column wrap, and applies it.

## Tooling

- Uses **mdformat** via `uvx` — no Node toolchain, fits the existing
  Python/`uv` setup.
- `mdformat-gfm` plugin so GFM tables (e.g. the platform table in
  `wasip1/README.md`) are preserved rather than collapsed.
- `mdformat-frontmatter` plugin so the YAML frontmatter on skill files is
  kept instead of being parsed as Markdown.
- `--number` keeps ordered lists numbered `1. 2. 3.` instead of all `1.`.

## File selection

The target lists files via `git ls-files '*.md'`, so:

- new Markdown is picked up automatically once tracked;
- vendored submodule test suites and gitignored dirs are never touched
  (their content isn't tracked by this repo);
- `CONTRIBUTING.md` (Google-owned) and the `CLAUDE.md` symlink are excluded.

## Notes

- Skill `description:` frontmatter is folded onto a single line by the
  frontmatter plugin; it's machine-read YAML and the skills still load.
- Remaining >80-column lines are all unbreakable URLs/badges in `README.md`
  and `wasip1/README.md`, which no formatter can wrap.