### PR TITLE
Format C benchmarks and add integer SIMD benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ fmt-md: check-uv ## Format repo-owned Markdown
 		--with mdformat-gfm==1.0.0 --with mdformat-frontmatter==2.1.2 \
 		mdformat@1.0.0 --wrap 80 --number
 
+fmt-c: $(WASI_SDK_CLANG) ## Format benchmark C sources
+	$(WASI_SDK_DIR)/bin/clang-format -i $(WASM_SRC_DIR)/*.c
+
 vet: ## Run go vet across the tree
 	go vet ./...
 
@@ -212,6 +215,6 @@ internal/spec_tests/testsuite/.git wasip1/wasi-testsuite/.git:
 
 # ----- phony declarations -----------------------------------------------------
 
-.PHONY: help build build-all run-example fmt fmt-md check-uv vet clean \
+.PHONY: help build build-all run-example fmt fmt-md fmt-c check-uv vet clean \
         distclean test test-spec test-wasi test-all bench bench-compare \
         build-wasm setup-wasi-sdk setup-wabt

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Targets:
   run-example           Run the basic example (smoke check)
   fmt                   Run gofmt across the tree
   fmt-md                Format repo-owned Markdown
+  fmt-c                 Format benchmark C sources
   vet                   Run go vet across the tree
   clean                 Remove built artifacts (keeps the wasi-sdk toolchain)
   distclean             Remove built artifacts AND the wasi-sdk toolchain

--- a/internal/benchmarks/benchmark_test.go
+++ b/internal/benchmarks/benchmark_test.go
@@ -121,6 +121,20 @@ func BenchmarkVectorMath(b *testing.B) {
 	}
 }
 
+func BenchmarkIntegerVectorMath(b *testing.B) {
+	instance, err := instantiate("wasm/vector_math.wasm")
+	if err != nil {
+		b.Fatalf("failed to initialize test: %v", err)
+	}
+
+	for b.Loop() {
+		_, err := instance.Invoke("compute_integer_vector_math", int32(100))
+		if err != nil {
+			b.Fatalf("failed to execute benchmark: %v", err)
+		}
+	}
+}
+
 func BenchmarkMemoryAccess(b *testing.B) {
 	instance, err := instantiate("wasm/memory_access.wasm")
 	if err != nil {

--- a/internal/benchmarks/src/.clang-format
+++ b/internal/benchmarks/src/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+InsertNewlineAtEOF: true

--- a/internal/benchmarks/src/.clangd
+++ b/internal/benchmarks/src/.clangd
@@ -1,0 +1,9 @@
+# clangd configuration (https://clangd.llvm.org/config).
+#
+# These sources are compiled for wasm (wasm32-wasip1) via `make build-wasm`,
+# where __attribute__((export_name(...))) is a valid Clang attribute. clangd,
+# however, parses them with the host target by default and reports the
+# attribute as unknown (-Wunknown-attributes). The build itself never warns;
+# silence only that one editor-side false positive.
+CompileFlags:
+  Add: [-Wno-unknown-attributes]

--- a/internal/benchmarks/src/.clangd
+++ b/internal/benchmarks/src/.clangd
@@ -1,9 +1,2 @@
-# clangd configuration (https://clangd.llvm.org/config).
-#
-# These sources are compiled for wasm (wasm32-wasip1) via `make build-wasm`,
-# where __attribute__((export_name(...))) is a valid Clang attribute. clangd,
-# however, parses them with the host target by default and reports the
-# attribute as unknown (-Wunknown-attributes). The build itself never warns;
-# silence only that one editor-side false positive.
 CompileFlags:
   Add: [-Wno-unknown-attributes]

--- a/internal/benchmarks/src/factorial.c
+++ b/internal/benchmarks/src/factorial.c
@@ -16,8 +16,7 @@
 
 #include <stdint.h>
 
-__attribute__((noinline))
-static int64_t fac_recursive_impl(int64_t n) {
+__attribute__((noinline)) static int64_t fac_recursive_impl(int64_t n) {
   if (n == 0) {
     return 1;
   }
@@ -29,8 +28,8 @@ static int64_t fac_recursive_impl(int64_t n) {
 
 // `n` is passed in (rather than hardcoded) so LLVM can't fold the inner
 // loop into a closed-form expression.
-__attribute__((export_name("fac_recursive")))
-int64_t fac_recursive(int32_t iterations, int64_t n) {
+__attribute__((export_name("fac_recursive"))) int64_t
+fac_recursive(int32_t iterations, int64_t n) {
   int64_t total = 0;
   for (int32_t i = 0; i < iterations; i++) {
     total += fac_recursive_impl(n);
@@ -38,8 +37,8 @@ int64_t fac_recursive(int32_t iterations, int64_t n) {
   return total;
 }
 
-__attribute__((export_name("fac_iterative")))
-int64_t fac_iterative(int32_t iterations, int64_t n) {
+__attribute__((export_name("fac_iterative"))) int64_t
+fac_iterative(int32_t iterations, int64_t n) {
   int64_t total = 0;
   for (int32_t iter = 0; iter < iterations; iter++) {
     int64_t fac = 1;

--- a/internal/benchmarks/src/fibonacci.c
+++ b/internal/benchmarks/src/fibonacci.c
@@ -16,8 +16,7 @@
 
 #include <stdint.h>
 
-__attribute__((noinline))
-static int fib_recursive_impl(int n) {
+__attribute__((noinline)) static int fib_recursive_impl(int n) {
   if (n == 0) {
     return 0;
   }
@@ -33,8 +32,8 @@ static int fib_recursive_impl(int n) {
 
 // `n` is passed in (rather than hardcoded) so LLVM can't fold the inner
 // loop into a closed-form expression.
-__attribute__((export_name("fib_recursive")))
-int fib_recursive(int32_t iterations, int32_t n) {
+__attribute__((export_name("fib_recursive"))) int fib_recursive(
+    int32_t iterations, int32_t n) {
   int total = 0;
   for (int32_t i = 0; i < iterations; i++) {
     total += fib_recursive_impl(n);
@@ -42,8 +41,8 @@ int fib_recursive(int32_t iterations, int32_t n) {
   return total;
 }
 
-__attribute__((export_name("fib_iterative")))
-int fib_iterative(int32_t iterations, int32_t n) {
+__attribute__((export_name("fib_iterative"))) int fib_iterative(
+    int32_t iterations, int32_t n) {
   int total = 0;
   for (int32_t iter = 0; iter < iterations; iter++) {
     int a = 0;

--- a/internal/benchmarks/src/host_call.c
+++ b/internal/benchmarks/src/host_call.c
@@ -16,11 +16,11 @@
 
 #include <stdint.h>
 
-__attribute__((import_module("env"), import_name("noop")))
-extern int32_t host_noop(int32_t x);
+__attribute__((import_module("env"), import_name("noop"))) extern int32_t
+host_noop(int32_t x);
 
-__attribute__((export_name("run_host_calls")))
-int32_t run_host_calls(int32_t iterations) {
+__attribute__((export_name("run_host_calls"))) int32_t
+run_host_calls(int32_t iterations) {
   int32_t result = 0;
   for (int32_t i = 0; i < iterations; i++) {
     result = host_noop(result + i);

--- a/internal/benchmarks/src/indirect.c
+++ b/internal/benchmarks/src/indirect.c
@@ -25,8 +25,8 @@ binary_op operations[] = {&add, &sub, &mul, &xor_op};
 
 #define NUM_OPS 4
 
-__attribute__((export_name("run_indirect_calls")))
-int run_indirect_calls(int iterations) {
+__attribute__((export_name("run_indirect_calls"))) int run_indirect_calls(
+    int iterations) {
   int result = 0;
   for (int i = 0; i < iterations; i++) {
     // Cycle through the functions in the operations table.

--- a/internal/benchmarks/src/matrix_multiplication.c
+++ b/internal/benchmarks/src/matrix_multiplication.c
@@ -26,8 +26,7 @@ float matrix_a[DIM][DIM];
 float matrix_b[DIM][DIM];
 float result_matrix[DIM][DIM];
 
-__attribute__((noinline))
-void multiply() {
+__attribute__((noinline)) void multiply() {
   for (int i = 0; i < DIM; i++) {
     for (int j = 0; j < DIM; j++) {
       float sum = 0.0f;
@@ -39,8 +38,8 @@ void multiply() {
   }
 }
 
-__attribute__((export_name("run_matrix_multiplication")))
-float run_matrix_multiplication(int iterations) {
+__attribute__((export_name("run_matrix_multiplication"))) float
+run_matrix_multiplication(int iterations) {
   // Initialize matrices with some values.
   for (int i = 0; i < DIM; i++) {
     for (int j = 0; j < DIM; j++) {

--- a/internal/benchmarks/src/memory_access.c
+++ b/internal/benchmarks/src/memory_access.c
@@ -18,8 +18,8 @@
  * the two 16 MiB buffers below.
  */
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 // 16 MiB (16 * 1024 * 1024 bytes)
 #define BUFFER_SIZE 16777216
@@ -27,8 +27,7 @@
 uint8_t source_buffer[BUFFER_SIZE];
 uint8_t destination_buffer[BUFFER_SIZE];
 
-__attribute__((export_name("run_memcpy")))
-uint32_t run_memcpy(int iterations) {
+__attribute__((export_name("run_memcpy"))) uint32_t run_memcpy(int iterations) {
   // Initialize source buffer.
   for (size_t i = 0; i < BUFFER_SIZE; ++i) {
     source_buffer[i] = (uint8_t)(i * 31 % 251);

--- a/internal/benchmarks/src/sha256.c
+++ b/internal/benchmarks/src/sha256.c
@@ -42,10 +42,8 @@ static uint8_t buffer[BUFFER_SIZE];
 static void process_block(uint32_t state[8], const uint8_t block[64]) {
   uint32_t w[64];
   for (int i = 0; i < 16; i++) {
-    w[i] = ((uint32_t)block[i * 4] << 24) |
-           ((uint32_t)block[i * 4 + 1] << 16) |
-           ((uint32_t)block[i * 4 + 2] << 8) |
-           ((uint32_t)block[i * 4 + 3]);
+    w[i] = ((uint32_t)block[i * 4] << 24) | ((uint32_t)block[i * 4 + 1] << 16) |
+           ((uint32_t)block[i * 4 + 2] << 8) | ((uint32_t)block[i * 4 + 3]);
   }
   for (int i = 16; i < 64; i++) {
     uint32_t s0 = ROTR(w[i - 15], 7) ^ ROTR(w[i - 15], 18) ^ (w[i - 15] >> 3);
@@ -101,8 +99,8 @@ static void sha256(uint8_t out[32]) {
   }
 }
 
-__attribute__((export_name("run_sha256")))
-uint32_t run_sha256(int32_t iterations) {
+__attribute__((export_name("run_sha256"))) uint32_t
+run_sha256(int32_t iterations) {
   for (int i = 0; i < BUFFER_SIZE; i++) {
     buffer[i] = (uint8_t)(i * 31 % 251);
   }

--- a/internal/benchmarks/src/sorting.c
+++ b/internal/benchmarks/src/sorting.c
@@ -109,8 +109,7 @@ int data_buffer[BUFFER_LENGTH];
 
 void init_data() { memcpy(data_buffer, original_data, sizeof(original_data)); }
 
-__attribute__((export_name("bubble_sort")))
-void bubble_sort() {
+__attribute__((export_name("bubble_sort"))) void bubble_sort() {
   init_data();
   for (int i = 0; i < BUFFER_LENGTH; i++) {
     for (int j = 0; j < BUFFER_LENGTH - i - 1; j++) {
@@ -123,7 +122,7 @@ void bubble_sort() {
   }
 }
 
-void merge_sort_internal(int *array, int left, int right) {
+void merge_sort_internal(int* array, int left, int right) {
   if (left >= right) {
     return;
   }
@@ -134,8 +133,8 @@ void merge_sort_internal(int *array, int left, int right) {
 
   int n1 = mid - left + 1;
   int n2 = right - mid;
-  int *left_array = (int *)malloc(n1 * sizeof(int));
-  int *right_array = (int *)malloc(n2 * sizeof(int));
+  int* left_array = (int*)malloc(n1 * sizeof(int));
+  int* right_array = (int*)malloc(n2 * sizeof(int));
   for (int i = 0; i < n1; i++) {
     left_array[i] = array[left + i];
   }
@@ -166,19 +165,18 @@ void merge_sort_internal(int *array, int left, int right) {
   free(right_array);
 }
 
-__attribute__((export_name("merge_sort")))
-void merge_sort() {
+__attribute__((export_name("merge_sort"))) void merge_sort() {
   init_data();
   merge_sort_internal(data_buffer, 0, BUFFER_LENGTH - 1);
 }
 
-void swap(int *a, int *b) {
+void swap(int* a, int* b) {
   int temp = *a;
   *a = *b;
   *b = temp;
 }
 
-int partition(int *array, int left, int right) {
+int partition(int* array, int left, int right) {
   int pivot = array[right];
   int i = left - 1;
 
@@ -192,8 +190,8 @@ int partition(int *array, int left, int right) {
   return i + 1;
 }
 
-__attribute__((noinline, disable_tail_calls))
-void quick_sort_internal(int *array, int left, int right) {
+__attribute__((noinline, disable_tail_calls)) void quick_sort_internal(
+    int* array, int left, int right) {
   if (left >= right) {
     return;
   }
@@ -202,8 +200,7 @@ void quick_sort_internal(int *array, int left, int right) {
   quick_sort_internal(array, pivot_index + 1, right);
 }
 
-__attribute__((export_name("quick_sort")))
-void quick_sort() {
+__attribute__((export_name("quick_sort"))) void quick_sort() {
   init_data();
   quick_sort_internal(data_buffer, 0, BUFFER_LENGTH - 1);
 }

--- a/internal/benchmarks/src/trigonometry.c
+++ b/internal/benchmarks/src/trigonometry.c
@@ -16,7 +16,6 @@
 
 #include <math.h>
 
-__attribute__((export_name("compute_sin")))
-float compute_sin(float n) {
+__attribute__((export_name("compute_sin"))) float compute_sin(float n) {
   return sin(n);
 }

--- a/internal/benchmarks/src/vector_math.c
+++ b/internal/benchmarks/src/vector_math.c
@@ -23,8 +23,8 @@
 
 #define VECTOR_SIZE 128
 
-__attribute__((export_name("compute_vector_math")))
-float compute_vector_math(int iterations) {
+__attribute__((export_name("compute_vector_math"))) float compute_vector_math(
+    int iterations) {
   float input[VECTOR_SIZE];
   float output[VECTOR_SIZE];
   double double_input[VECTOR_SIZE / 2];
@@ -34,8 +34,8 @@ float compute_vector_math(int iterations) {
 
   // Initialize input arrays with values that will stress different operations
   for (int i = 0; i < VECTOR_SIZE; i++) {
-    input[i] = 1.0f + 0.5f * i; // Positive values for sqrt
-    int_input[i] = i - 64;      // Mix of positive and negative values
+    input[i] = 1.0f + 0.5f * i;  // Positive values for sqrt
+    int_input[i] = i - 64;       // Mix of positive and negative values
   }
 
   for (int i = 0; i < VECTOR_SIZE / 2; i++) {
@@ -50,7 +50,7 @@ float compute_vector_math(int iterations) {
 
     // Test floating-point rounding operations
     for (int i = 0; i < VECTOR_SIZE; i++) {
-      float x = input[i] + 0.25f; // Add offset to make rounding meaningful
+      float x = input[i] + 0.25f;  // Add offset to make rounding meaningful
       float ceil_val = ceilf(x);
       float floor_val = floorf(x);
       float trunc_val = truncf(x);
@@ -89,9 +89,9 @@ float compute_vector_math(int iterations) {
 
     // Test division and min/max operations
     for (int i = 0; i < VECTOR_SIZE; i++) {
-      float x = fmaxf(input[i], 0.1f);   // f32x4.max
-      float y = fminf(output[i], 10.0f); // f32x4.min
-      float div_result = x / y;          // f32x4.div
+      float x = fmaxf(input[i], 0.1f);    // f32x4.max
+      float y = fminf(output[i], 10.0f);  // f32x4.min
+      float div_result = x / y;           // f32x4.div
 
       output[i] = div_result;
     }
@@ -103,6 +103,61 @@ float compute_vector_math(int iterations) {
     for (int i = 0; i < VECTOR_SIZE / 2; i++) {
       result += (float)double_output[i] * 0.01f;
     }
+  }
+
+  return result;
+}
+
+// The same set of element-wise operations applied to one lane width. `width`
+// is the C type (int8_t, int16_t, ...) and `acc` is the running result. With
+// -msimd128 each loop becomes the matching i8x16 / i16x8 / i32x4 / i64x2 SIMD
+// instruction. `mul` is gated because 8-bit lanes have no SIMD multiply.
+#define LANE_OPS(width, a, b, out, acc, mul)                          \
+  do {                                                                \
+    for (int i = 0; i < VECTOR_SIZE; i++)                             \
+      out[i] = (mul) ? (width)(a[i] * b[i]) : (width)(a[i] + b[i]);   \
+    for (int i = 0; i < VECTOR_SIZE; i++) out[i] += a[i] - b[i];      \
+    for (int i = 0; i < VECTOR_SIZE; i++)                             \
+      out[i] += a[i] < b[i] ? a[i] : b[i]; /* min */                  \
+    for (int i = 0; i < VECTOR_SIZE; i++)                             \
+      out[i] += a[i] > b[i] ? a[i] : b[i]; /* max */                  \
+    for (int i = 0; i < VECTOR_SIZE; i++)                             \
+      out[i] ^= a[i] & b[i]; /* and, then xor into the accumulator */ \
+    for (int i = 0; i < VECTOR_SIZE; i++) out[i] |= b[i]; /* or */    \
+    for (int i = 0; i < VECTOR_SIZE; i++)                             \
+      out[i] += b[i] << 1; /* shift left (b is positive) */           \
+    for (int i = 0; i < VECTOR_SIZE; i++)                             \
+      out[i] += a[i] >> 1; /* shift right */                          \
+    for (int i = 0; i < VECTOR_SIZE; i++) acc += out[i];              \
+  } while (0)
+
+__attribute__((export_name("compute_integer_vector_math"))) int64_t
+compute_integer_vector_math(int iterations) {
+  int8_t a8[VECTOR_SIZE], b8[VECTOR_SIZE], o8[VECTOR_SIZE];
+  int16_t a16[VECTOR_SIZE], b16[VECTOR_SIZE], o16[VECTOR_SIZE];
+  int32_t a32[VECTOR_SIZE], b32[VECTOR_SIZE], o32[VECTOR_SIZE];
+  int64_t a64[VECTOR_SIZE], b64[VECTOR_SIZE], o64[VECTOR_SIZE];
+  int64_t result = 0;
+
+  // Small inputs: `a` is signed, `b` is positive. Kept tiny to stay in range.
+  for (int i = 0; i < VECTOR_SIZE; i++) {
+    int signed_value = (i % 9) - 4;    // -4..4
+    int positive_value = (i % 7) + 1;  // 1..7
+    a8[i] = signed_value;
+    b8[i] = positive_value;
+    a16[i] = signed_value;
+    b16[i] = positive_value;
+    a32[i] = signed_value;
+    b32[i] = positive_value;
+    a64[i] = signed_value;
+    b64[i] = positive_value;
+  }
+
+  for (int iter = 0; iter < iterations; iter++) {
+    LANE_OPS(int8_t, a8, b8, o8, result, 0);      // i8x16 (no SIMD multiply)
+    LANE_OPS(int16_t, a16, b16, o16, result, 1);  // i16x8
+    LANE_OPS(int32_t, a32, b32, o32, result, 1);  // i32x4
+    LANE_OPS(int64_t, a64, b64, o64, result, 1);  // i64x2
   }
 
   return result;


### PR DESCRIPTION
This PR formats the benchmark C sources using `clang-format` (Google style) and introduces a new integer SIMD benchmark (`BenchmarkIntegerVectorMath`) exercising 8-bit, 16-bit, 32-bit, and 64-bit vector operations.