### PR TITLE
Decouple wasip1 from host syscalls behind a FileSystem interface

### DIFF
--- a/cmd/epsilon/main.go
+++ b/cmd/epsilon/main.go
@@ -202,12 +202,12 @@ func newWASIModule(opts options) (*wasip1.WasiModule, error) {
 		if !ok {
 			guestPath = hostPath
 		}
-		file, err := os.Open(hostPath)
+		fsys, err := wasip1.OpenHostFileSystem(hostPath)
 		if err != nil {
 			builder.Close()
 			return nil, fmt.Errorf("failed to open preopen %q: %w", hostPath, err)
 		}
-		builder = builder.WithDir(guestPath, file)
+		builder = builder.WithFS(guestPath, fsys)
 	}
 
 	return builder.Build()

--- a/wasip1/README.md
+++ b/wasip1/README.md
@@ -14,7 +14,12 @@ This package provides a
 | macOS    | ✅ Supported     |
 | Windows  | ❌ Not Supported |
 
-On non-Unix platforms, `NewWasiModuleBuilder().Build()` returns an error.
+The core WASI logic is platform-agnostic and compiles everywhere; it talks to
+the host only through the `FileSystem`/`File` interfaces (see
+[Filesystem](#filesystem)). The only bundled backend is the syscall-based host
+backend, which is Unix-only, so on non-Unix platforms
+`NewWasiModuleBuilder().Build()` (and `OpenHostFileSystem`/`NewHostFile`) return
+an error unless every preopen and stream is supplied via a custom backend.
 
 ## Usage
 
@@ -33,14 +38,14 @@ func main() {
 	wasm, _ := os.ReadFile("guest.wasm")
 
 	// Open a directory to pre-open for the WASM module
-	dir, _ := os.Open("/path/to/sandbox")
+	fsys, _ := wasip1.OpenHostFileSystem("/path/to/sandbox")
 
 	// Create a WASI module with args, env, and a pre-opened directory
 	wasiModule, _ := wasip1.NewWasiModuleBuilder().
 		WithArgs("guest.wasm", "--verbose", "--count=42").
 		WithEnv("GREETING", "Hello from WASI!").
 		WithEnv("USER", "wasm_user").
-		WithDir("/sandbox", dir).
+		WithFS("/sandbox", fsys).
 		Build()
 	defer wasiModule.Close()
 
@@ -60,6 +65,34 @@ func main() {
 	}
 }
 ```
+
+## Filesystem
+
+The runtime accesses the host through two interfaces (see `wasi_types.go`), so
+the WASI state machine is decoupled from the host OS.
+
+- `FileSystem` is a sandboxed, directory-rooted capability. Every WASI directory
+  descriptor (a preopen, or a directory from `path_open`) is one `FileSystem`.
+  All names resolve relative to its root and cannot escape it.
+- `File` is an open file, directory, or socket handle. It extends `io/fs.File`
+  with the write, seek, and metadata operations WASI needs.
+
+The default host backend resolves every path relative to the sandbox root with
+`*at` syscalls. It blocks `..` traversal and symlink escapes, and never follows
+a path outside the root.
+
+Mount any `FileSystem` with `WithFS`. Open a host directory with
+`OpenHostFileSystem`.
+
+```go
+// Open a host directory, or supply your own FileSystem.
+fsys, _ := wasip1.OpenHostFileSystem("/path/to/sandbox")
+builder.WithFS("/sandbox", fsys)
+```
+
+The stream methods (`WithStdin`/`WithStdout`/`WithStderr`) also take a `File`.
+Wrap a host `*os.File` with `NewHostFile`. The builder takes ownership of every
+`FileSystem` and `File` it is given. It never closes the process stdio.
 
 ## Testing
 

--- a/wasip1/wasi.go
+++ b/wasip1/wasi.go
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unix
-
 package wasip1
 
 import (
-	"cmp"
 	"crypto/rand"
 	"maps"
 	"os"
@@ -31,9 +28,9 @@ type WasiModuleBuilder struct {
 	args     []string
 	env      map[string]string
 	preopens []WasiPreopen
-	stdin    *os.File
-	stdout   *os.File
-	stderr   *os.File
+	stdin    File
+	stdout   File
+	stderr   File
 }
 
 type WasiModule struct {
@@ -72,27 +69,31 @@ func (b *WasiModuleBuilder) WithEnvMap(
 	return b
 }
 
-// WithDir mounts a directory with default rights.
-func (b *WasiModuleBuilder) WithDir(
+// WithFS mounts a FileSystem at guestPath with default rights. This is the
+// backend-agnostic preopen entry point; the FileSystem may be the default
+// host implementation (see OpenHostFileSystem) or any custom implementation.
+// The builder takes ownership of fsys.
+func (b *WasiModuleBuilder) WithFS(
 	guestPath string,
-	hostDir *os.File,
+	fsys FileSystem,
 ) *WasiModuleBuilder {
-	return b.WithDirRights(
+	return b.WithFSRights(
 		guestPath,
-		hostDir,
+		fsys,
 		DefaultDirRights,
 		DefaultDirInheritingRights,
 	)
 }
 
-// WithDirRights mounts a directory with explicit rights.
-func (b *WasiModuleBuilder) WithDirRights(
+// WithFSRights mounts a FileSystem at guestPath with explicit rights. The
+// builder takes ownership of fsys.
+func (b *WasiModuleBuilder) WithFSRights(
 	guestPath string,
-	hostDir *os.File,
+	fsys FileSystem,
 	rights, rightsInheriting int64,
 ) *WasiModuleBuilder {
 	b.preopens = append(b.preopens, WasiPreopen{
-		File:             hostDir,
+		FS:               fsys,
 		GuestPath:        guestPath,
 		Rights:           rights,
 		RightsInheriting: rightsInheriting,
@@ -100,37 +101,36 @@ func (b *WasiModuleBuilder) WithDirRights(
 	return b
 }
 
-// WithStdin overrides the default stdin (os.Stdin) for the WASI module.
-func (b *WasiModuleBuilder) WithStdin(f *os.File) *WasiModuleBuilder {
+// WithStdin overrides the default stdin (os.Stdin) for the WASI module. The
+// builder takes ownership of f. Wrap a host *os.File with NewHostFile.
+func (b *WasiModuleBuilder) WithStdin(f File) *WasiModuleBuilder {
 	b.stdin = f
 	return b
 }
 
-// WithStdout overrides the default stdout (os.Stdout) for the WASI module.
-func (b *WasiModuleBuilder) WithStdout(f *os.File) *WasiModuleBuilder {
+// WithStdout overrides the default stdout (os.Stdout) for the WASI module. The
+// builder takes ownership of f. Wrap a host *os.File with NewHostFile.
+func (b *WasiModuleBuilder) WithStdout(f File) *WasiModuleBuilder {
 	b.stdout = f
 	return b
 }
 
-// WithStderr overrides the default stderr (os.Stderr) for the WASI module.
-func (b *WasiModuleBuilder) WithStderr(f *os.File) *WasiModuleBuilder {
+// WithStderr overrides the default stderr (os.Stderr) for the WASI module. The
+// builder takes ownership of f. Wrap a host *os.File with NewHostFile.
+func (b *WasiModuleBuilder) WithStderr(f File) *WasiModuleBuilder {
 	b.stderr = f
 	return b
 }
 
 // Build constructs a WasiModule from the builder configuration.
 //
-// Build takes ownership of all *os.Files provided via WithDir, WithStdin,
-// WithStdout, and WithStderr, regardless of whether Build succeeds or fails.
-// On success, call Close() on the WasiModule to release resources.
-// On failure, Build closes all provided files before returning.
+// Build takes ownership of every FileSystem and File provided (via WithFS,
+// WithStdin, WithStdout, WithStderr), regardless of whether Build succeeds or
+// fails. On success, call Close() on the WasiModule to release resources. On
+// failure, Build closes all provided resources before returning. Streams not
+// overridden default to the process stdio, which is never closed.
 func (b *WasiModuleBuilder) Build() (*WasiModule, error) {
-	fs, err := newWasiResourceTable(
-		b.preopens,
-		cmp.Or(b.stdin, os.Stdin),
-		cmp.Or(b.stdout, os.Stdout),
-		cmp.Or(b.stderr, os.Stderr),
-	)
+	fs, err := b.buildResourceTable()
 	if err != nil {
 		b.Close()
 		return nil, err
@@ -143,12 +143,42 @@ func (b *WasiModuleBuilder) Build() (*WasiModule, error) {
 	}, nil
 }
 
+func (b *WasiModuleBuilder) buildResourceTable() (*wasiResourceTable, error) {
+	stdin, err := resolveStdStream(b.stdin, os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := resolveStdStream(b.stdout, os.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := resolveStdStream(b.stderr, os.Stderr)
+	if err != nil {
+		return nil, err
+	}
+	return newWasiResourceTable(b.preopens, stdin, stdout, stderr)
+}
+
+// resolveStdStream wraps the user-provided stream, or falls back to the process
+// stdio. The process stdio is marked keepOpen so it is never closed.
+func resolveStdStream(custom File, fallback *os.File) (stdStream, error) {
+	if custom != nil {
+		return stdStream{file: custom, keepOpen: false}, nil
+	}
+	f, err := NewHostFile(fallback)
+	if err != nil {
+		return stdStream{}, err
+	}
+	return stdStream{file: f, keepOpen: true}, nil
+}
+
 // Close releases all resources accumulated by the builder without constructing
 // a WasiModule. Use this if you need to abort builder usage before calling
-// Build(), for example if an error occurs while setting up directories.
+// Build(), for example if an error occurs while setting up directories. The
+// process stdio is never closed.
 func (b *WasiModuleBuilder) Close() {
 	for _, preopen := range b.preopens {
-		preopen.File.Close()
+		preopen.FS.Close()
 	}
 	if b.stdin != nil {
 		b.stdin.Close()

--- a/wasip1/wasi_poll.go
+++ b/wasip1/wasi_poll.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unix
-
 package wasip1
 
 import (
@@ -191,7 +189,7 @@ func (w *WasiModule) handleFdSubscription(sub subscription) *event {
 	}
 
 	var nbytes uint64
-	if fd.fileType == fileTypeRegularFile && fd.rights&RightsFdFilestatGet != 0 {
+	if fd.fileType == FileTypeRegularFile && fd.rights&RightsFdFilestatGet != 0 {
 		if info, err := fd.file.Stat(); err == nil {
 			nbytes = uint64(info.Size())
 		}

--- a/wasip1/wasi_resources.go
+++ b/wasip1/wasi_resources.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unix
-
 package wasip1
 
 import (
@@ -21,6 +19,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/ziggy42/epsilon/epsilon"
 )
@@ -30,17 +29,25 @@ const maxFileDescriptors = 2048
 var errMaxFileDescriptorsReached = errors.New("max file descriptors reached")
 
 type wasiFileDescriptor struct {
-	file             *os.File
-	fileType         uint8
+	file             File
+	fsRoot           FileSystem // non-nil for directory descriptors
+	fileType         FileType
 	flags            uint16
 	rights           int64
 	rightsInheriting int64
 	guestPath        string
 	isPreopen        bool
+	keepOpen         bool // std streams the runtime must not close
 }
 
 func (fd *wasiFileDescriptor) close() {
-	if fd.file != os.Stdin && fd.file != os.Stdout && fd.file != os.Stderr {
+	if fd.fsRoot != nil {
+		// fsRoot.Close releases both the directory's open handle (fd.file) and
+		// the underlying root.
+		fd.fsRoot.Close()
+		return
+	}
+	if !fd.keepOpen {
 		fd.file.Close()
 	}
 }
@@ -55,9 +62,16 @@ func (rt *wasiResourceTable) closeAll() {
 	}
 }
 
+// stdStream is a resolved standard stream: the backing File and whether the
+// runtime must leave it open (true for the process stdio).
+type stdStream struct {
+	file     File
+	keepOpen bool
+}
+
 func newWasiResourceTable(
 	preopens []WasiPreopen,
-	stdin, stdout, stderr *os.File,
+	stdin, stdout, stderr stdStream,
 ) (*wasiResourceTable, error) {
 	stdRights := RightsFdFilestatGet | RightsPollFdReadwrite
 	stdinFd, err := newStdFileDescriptor(stdin, RightsFdRead|stdRights)
@@ -77,13 +91,17 @@ func newWasiResourceTable(
 		fds: map[int32]*wasiFileDescriptor{0: stdinFd, 1: stdoutFd, 2: stderrFd},
 	}
 
-	for _, dir := range preopens {
-		fd, err := newPreopenFileDescriptor(dir)
+	for _, pre := range preopens {
+		fd, err := newPreopenFileDescriptor(pre)
 		if err != nil {
+			pre.FS.Close()
+			resourceTable.closeAll()
 			return nil, err
 		}
 		newFdIndex, err := resourceTable.allocateFdIndex()
 		if err != nil {
+			fd.close()
+			resourceTable.closeAll()
 			return nil, err
 		}
 		resourceTable.fds[newFdIndex] = fd
@@ -91,14 +109,22 @@ func newWasiResourceTable(
 	return resourceTable, nil
 }
 
+// newFileDescriptor wraps file as a descriptor. If info is non-nil it is the
+// caller's already-fetched stat of file, avoiding a redundant Stat; otherwise
+// file is stat'd here.
 func newFileDescriptor(
-	file *os.File,
+	file File,
+	fsRoot FileSystem,
+	info os.FileInfo,
 	rights, rightsInheriting int64,
 	flags uint16,
 ) (*wasiFileDescriptor, error) {
-	info, err := file.Stat()
-	if err != nil {
-		return nil, err
+	if info == nil {
+		var err error
+		info, err = file.Stat()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if info.IsDir() {
@@ -107,6 +133,7 @@ func newFileDescriptor(
 
 	return &wasiFileDescriptor{
 		file:             file,
+		fsRoot:           fsRoot,
 		fileType:         getModeFileType(info.Mode()),
 		flags:            flags,
 		rights:           rights,
@@ -116,8 +143,17 @@ func newFileDescriptor(
 	}, nil
 }
 
-func newPreopenFileDescriptor(pre WasiPreopen) (*wasiFileDescriptor, error) {
-	fd, err := newFileDescriptor(pre.File, pre.Rights, pre.RightsInheriting, 0)
+func newPreopenFileDescriptor(
+	pre WasiPreopen,
+) (*wasiFileDescriptor, error) {
+	fd, err := newFileDescriptor(
+		pre.FS.Handle(),
+		pre.FS,
+		nil,
+		pre.Rights,
+		pre.RightsInheriting,
+		0,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -127,10 +163,15 @@ func newPreopenFileDescriptor(pre WasiPreopen) (*wasiFileDescriptor, error) {
 }
 
 func newStdFileDescriptor(
-	file *os.File,
+	stream stdStream,
 	rights int64,
 ) (*wasiFileDescriptor, error) {
-	return newFileDescriptor(file, rights, 0, 0)
+	fd, err := newFileDescriptor(stream.file, nil, nil, rights, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	fd.keepOpen = stream.keepOpen
+	return fd, nil
 }
 
 func (w *wasiResourceTable) advise(
@@ -217,7 +258,9 @@ func (w *wasiResourceTable) setStatFlags(fdIndex, fdFlags int32) int32 {
 
 	fd.flags = uint16(fdFlags)
 
-	if err := setFdFlags(fd.file, fdFlags); err != nil {
+	appendFlag := fdFlags&int32(fdFlagsAppend) != 0
+	nonblock := fdFlags&int32(fdFlagsNonblock) != 0
+	if err := fd.file.SetFlags(appendFlag, nonblock); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -254,7 +297,7 @@ func (w *wasiResourceTable) getFileStat(
 		return errCode
 	}
 
-	fs, err := fdstat(fd.file)
+	fs, err := fd.file.FileStat()
 	if err != nil {
 		return mapError(err)
 	}
@@ -272,7 +315,7 @@ func (w *wasiResourceTable) setFileStatSize(fdIndex int32, size int64) int32 {
 		return errCode
 	}
 
-	if fd.fileType == fileTypeDirectory {
+	if fd.fileType == FileTypeDirectory {
 		return errnoIsDir
 	}
 
@@ -292,7 +335,7 @@ func (w *wasiResourceTable) setFileStatTimes(
 		return errCode
 	}
 
-	if err := utimesNanoAt(fd.file, atim, mtim, fstFlags); err != nil {
+	if err := fd.file.SetTimes(atim, mtim, fstFlags); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -375,7 +418,7 @@ func (w *wasiResourceTable) pwrite(
 
 	currentOffset := offset
 	writeBytes := func(data []byte) (int, error) {
-		n, err := writeAt(fd.file, data, currentOffset, fd.flags&fdFlagsAppend != 0)
+		n, err := fd.file.WriteAt(data, currentOffset)
 		currentOffset += int64(n)
 		return n, err
 	}
@@ -414,7 +457,7 @@ func (w *wasiResourceTable) readdir(
 		return errCode
 	}
 
-	entries, err := readDirEntries(fd.file)
+	entries, err := fd.fsRoot.ReadDir()
 	if err != nil {
 		return mapError(err)
 	}
@@ -570,7 +613,7 @@ func (w *wasiResourceTable) pathCreateDirectory(
 		return errnoFault
 	}
 
-	if err := mkdirat(fd.file, path, 0o755); err != nil {
+	if err := fd.fsRoot.Mkdir(path, 0o755); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -591,7 +634,7 @@ func (w *wasiResourceTable) pathFilestatGet(
 	}
 
 	followSymlinks := flags&lookupFlagsSymlinkFollow != 0
-	fs, err := stat(fd.file, path, followSymlinks)
+	fs, err := fd.fsRoot.Stat(path, followSymlinks)
 	if err != nil {
 		return mapError(err)
 	}
@@ -620,7 +663,7 @@ func (w *wasiResourceTable) pathFilestatSetTimes(
 	}
 
 	followSymlinks := flags&lookupFlagsSymlinkFollow != 0
-	err = utimes(fd.file, path, atim, mtim, fstFlags, followSymlinks)
+	err = fd.fsRoot.Chtimes(path, atim, mtim, fstFlags, followSymlinks)
 	if err != nil {
 		return mapError(err)
 	}
@@ -653,7 +696,7 @@ func (w *wasiResourceTable) pathLink(
 	}
 
 	followSymlinks := oldFlags&lookupFlagsSymlinkFollow != 0
-	err = linkat(oldFd.file, oldPath, followSymlinks, newFd.file, newPath)
+	err = oldFd.fsRoot.Link(oldPath, followSymlinks, newFd.fsRoot, newPath)
 	if err != nil {
 		return mapError(err)
 	}
@@ -698,14 +741,66 @@ func (w *wasiResourceTable) pathOpen(
 	}
 
 	followSymlinks := dirflags&lookupFlagsSymlinkFollow != 0
-	rights := uint64(rightsBase)
-	file, err := openat(fd.file, path, followSymlinks, oflags, fdflags, rights)
-	if err != nil {
-		return mapError(err)
+	// A trailing slash or an explicit O_DIRECTORY means the path must be a
+	// directory, which becomes its own sandboxed root.
+	wantDir := oflags&int32(oFlagsDirectory) != 0 ||
+		strings.HasSuffix(path, "/")
+
+	var file File
+	var childFS FileSystem
+	var info os.FileInfo
+	if wantDir {
+		// A directory cannot be opened for writing.
+		if rightsBase&RightsFdWrite != 0 {
+			return errnoIsDir
+		}
+		// Without symlink-follow, a symlink named as a directory must not be
+		// followed; opening it as a directory fails.
+		if !followSymlinks {
+			if info, serr := fd.fsRoot.Stat(path, false); serr == nil &&
+				info.FileType == FileTypeSymbolicLink {
+				return errnoLoop
+			}
+		}
+		childFS, err = fd.fsRoot.OpenRoot(path)
+		if err != nil {
+			return mapError(err)
+		}
+		file = childFS.Handle()
+	} else {
+		file, err = fd.fsRoot.OpenFile(
+			path,
+			followSymlinks,
+			oflags,
+			fdflags,
+			uint64(rightsBase),
+		)
+		if err != nil {
+			return mapError(err)
+		}
+
+		// A directory may be opened without O_DIRECTORY; promote it to a root so
+		// subsequent path operations on the descriptor work.
+		info, err = file.Stat()
+		if err != nil {
+			file.Close()
+			return mapError(err)
+		}
+		if info.IsDir() {
+			file.Close()
+			childFS, err = fd.fsRoot.OpenRoot(path)
+			if err != nil {
+				return mapError(err)
+			}
+			file = childFS.Handle()
+			info = nil // file now refers to the root handle; re-stat in allocateFd
+		}
 	}
 
 	newFdIndex, errCode := w.allocateFd(
 		file,
+		childFS,
+		info,
 		rightsBase,
 		rightsInheriting,
 		uint16(fdflags),
@@ -740,7 +835,7 @@ func (w *wasiResourceTable) pathReadlink(
 		return errnoFault
 	}
 
-	target, err := readlink(fd.file, path)
+	target, err := fd.fsRoot.Readlink(path)
 	if err != nil {
 		return mapError(err)
 	}
@@ -771,7 +866,7 @@ func (w *wasiResourceTable) pathRemoveDirectory(
 		return errnoFault
 	}
 
-	if err := rmdirat(fd.file, path); err != nil {
+	if err := fd.fsRoot.Rmdir(path); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -801,7 +896,7 @@ func (w *wasiResourceTable) pathRename(
 		return errnoFault
 	}
 
-	if err := renameat(oldFd.file, oldPath, newFd.file, newPath); err != nil {
+	if err := oldFd.fsRoot.Rename(newFd.fsRoot, oldPath, newPath); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -826,7 +921,7 @@ func (w *wasiResourceTable) pathSymlink(
 		return errnoFault
 	}
 
-	if err := symlinkat(targetPath, fd.file, linkPath); err != nil {
+	if err := fd.fsRoot.Symlink(targetPath, linkPath); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -846,7 +941,7 @@ func (w *wasiResourceTable) pathUnlinkFile(
 		return errnoFault
 	}
 
-	if err := unlinkat(fd.file, path); err != nil {
+	if err := fd.fsRoot.Unlink(path); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -861,12 +956,11 @@ func (w *wasiResourceTable) sockAccept(
 		return errCode
 	}
 
-	connectedSocketFd, err := accept(fd.file)
+	newFile, err := fd.file.Accept()
 	if err != nil {
 		return mapError(err)
 	}
 
-	newFile := os.NewFile(uintptr(connectedSocketFd), "")
 	// The accepted socket inherits its rights from the listener's
 	// rights_inheriting mask.
 	rights := fd.rightsInheriting
@@ -874,6 +968,8 @@ func (w *wasiResourceTable) sockAccept(
 	inheritRights := fd.rightsInheriting
 	newFdIndex, errCode := w.allocateFd(
 		newFile,
+		nil,
+		nil,
 		rights,
 		inheritRights,
 		uint16(flags),
@@ -941,7 +1037,7 @@ func (w *wasiResourceTable) sockShutdown(fdIndex, how int32) int32 {
 		return errCode
 	}
 
-	if err := shutdown(fd.file, how); err != nil {
+	if err := fd.file.Shutdown(how); err != nil {
 		return mapError(err)
 	}
 	return errnoSuccess
@@ -963,13 +1059,19 @@ func (w *wasiResourceTable) allocateFdIndex() (int32, error) {
 // allocateFd allocates a new file descriptor and returns its index and an error
 // code.
 func (w *wasiResourceTable) allocateFd(
-	file *os.File,
+	file File,
+	fsRoot FileSystem,
+	info os.FileInfo,
 	rights, inheritRights int64,
 	flags uint16,
 ) (int32, int32) {
-	fd, err := newFileDescriptor(file, rights, inheritRights, flags)
+	fd, err := newFileDescriptor(file, fsRoot, info, rights, inheritRights, flags)
 	if err != nil {
-		file.Close()
+		if fsRoot != nil {
+			fsRoot.Close()
+		} else {
+			file.Close()
+		}
 		return 0, mapError(err)
 	}
 	newFdIndex, err := w.allocateFdIndex()
@@ -989,7 +1091,7 @@ func (w *wasiResourceTable) getFile(
 	if errCode != errnoSuccess {
 		return nil, errCode
 	}
-	if fd.fileType == fileTypeDirectory {
+	if fd.fileType == FileTypeDirectory {
 		return nil, errnoIsDir
 	}
 	return fd, errnoSuccess
@@ -1003,7 +1105,7 @@ func (w *wasiResourceTable) getDir(
 	if errCode != errnoSuccess {
 		return nil, errCode
 	}
-	if fd.fileType != fileTypeDirectory {
+	if fd.fileType != FileTypeDirectory {
 		return nil, errnoNotDir
 	}
 	return fd, errnoSuccess
@@ -1031,7 +1133,7 @@ func (w *wasiResourceTable) getSocket(
 	if !ok {
 		return nil, errnoBadF
 	}
-	if fd.fileType != fileTypeSocketDgram && fd.fileType != fileTypeSocketStream {
+	if fd.fileType != FileTypeSocketDgram && fd.fileType != FileTypeSocketStream {
 		return nil, errnoNotSock
 	}
 	if fd.rights&rights == 0 {
@@ -1122,24 +1224,24 @@ func iterCiovec(
 	return errnoSuccess
 }
 
-func getModeFileType(mode os.FileMode) uint8 {
+func getModeFileType(mode os.FileMode) FileType {
 	switch {
 	case mode.IsDir():
-		return fileTypeDirectory
+		return FileTypeDirectory
 	case mode.IsRegular():
-		return fileTypeRegularFile
+		return FileTypeRegularFile
 	case mode&os.ModeSymlink != 0:
-		return fileTypeSymbolicLink
+		return FileTypeSymbolicLink
 	case mode&os.ModeSocket != 0:
-		return fileTypeSocketStream
+		return FileTypeSocketStream
 	case mode&os.ModeNamedPipe != 0:
-		return fileTypeCharacterDevice
+		return FileTypeCharacterDevice
 	case mode&os.ModeCharDevice != 0:
-		return fileTypeCharacterDevice
+		return FileTypeCharacterDevice
 	case mode&os.ModeDevice != 0:
-		return fileTypeBlockDevice
+		return FileTypeBlockDevice
 	default:
-		return fileTypeUnknown
+		return FileTypeUnknown
 	}
 }
 

--- a/wasip1/wasi_resources_test.go
+++ b/wasip1/wasi_resources_test.go
@@ -27,13 +27,12 @@ import (
 )
 
 func TestRightsEscalation_FdSync(t *testing.T) {
-	_, dirFd := testFS(t, file("test.txt", "hello"))
-	defer dirFd.Close()
+	_, fsys := testHostFS(t, file("test.txt", "hello"))
 
 	// Open file WITH RightsFdRead but WITHOUT RightsFdSync
-	f, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
+	f, err := fsys.OpenFile("test.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
-		t.Fatalf("openat failed: %v", err)
+		t.Fatalf("OpenFile failed: %v", err)
 	}
 	defer f.Close()
 
@@ -41,7 +40,7 @@ func TestRightsEscalation_FdSync(t *testing.T) {
 		fds: map[int32]*wasiFileDescriptor{
 			3: {
 				file:     f,
-				fileType: fileTypeRegularFile,
+				fileType: FileTypeRegularFile,
 				rights:   RightsFdRead,
 			},
 		},
@@ -55,12 +54,11 @@ func TestRightsEscalation_FdSync(t *testing.T) {
 }
 
 func TestRightsEscalation_FdFilestatGet(t *testing.T) {
-	_, dirFd := testFS(t, file("test.txt", "hello"))
-	defer dirFd.Close()
+	_, fsys := testHostFS(t, file("test.txt", "hello"))
 
-	f, err := openat(dirFd, "test.txt", false, 0, 0, uint64(RightsFdRead))
+	f, err := fsys.OpenFile("test.txt", false, 0, 0, uint64(RightsFdRead))
 	if err != nil {
-		t.Fatalf("openat failed: %v", err)
+		t.Fatalf("OpenFile failed: %v", err)
 	}
 	defer f.Close()
 
@@ -70,7 +68,7 @@ func TestRightsEscalation_FdFilestatGet(t *testing.T) {
 		fds: map[int32]*wasiFileDescriptor{
 			3: {
 				file:     f,
-				fileType: fileTypeRegularFile,
+				fileType: FileTypeRegularFile,
 				rights:   RightsFdRead, // Missing RightsFdFilestatGet
 			},
 		},
@@ -95,11 +93,16 @@ func TestRightsEscalation_SockShutdown(t *testing.T) {
 	}
 	defer file.Close()
 
+	sockFile, err := NewHostFile(file)
+	if err != nil {
+		t.Fatalf("newHostFile failed: %v", err)
+	}
+
 	rt := &wasiResourceTable{
 		fds: map[int32]*wasiFileDescriptor{
 			3: {
-				file:     file,
-				fileType: fileTypeSocketStream,
+				file:     sockFile,
+				fileType: FileTypeSocketStream,
 				rights:   0, // No rights
 			},
 		},
@@ -140,11 +143,16 @@ func TestRightsEscalation_SockAccept_Inheritance(t *testing.T) {
 	// rightsInheriting.
 	const customRight = RightsFdRead
 
+	sockFile, err := NewHostFile(file)
+	if err != nil {
+		t.Fatalf("newHostFile failed: %v", err)
+	}
+
 	rt := &wasiResourceTable{
 		fds: map[int32]*wasiFileDescriptor{
 			3: {
-				file:             file,
-				fileType:         fileTypeSocketStream,
+				file:             sockFile,
+				fileType:         FileTypeSocketStream,
 				rights:           rightsAll,
 				rightsInheriting: customRight,
 			},

--- a/wasip1/wasi_stub.go
+++ b/wasip1/wasi_stub.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,87 +19,21 @@ package wasip1
 import (
 	"errors"
 	"os"
-
-	"github.com/ziggy42/epsilon/epsilon"
 )
 
-// WasiModuleBuilder is a builder for creating WasiModule instances.
-// On non-Unix platforms, WASI is not supported.
-type WasiModuleBuilder struct {
-	files []*os.File
+// errUnsupportedPlatform is returned when constructing the host filesystem
+// backend on a platform that does not support it. The core WASI state machine
+// compiles everywhere; only the syscall-based host backend is Unix-only.
+var errUnsupportedPlatform = errors.New("WASI is not supported on this platform")
+
+// OpenHostFileSystem reports that the syscall-based host backend is
+// unavailable on this platform.
+func OpenHostFileSystem(dir string) (FileSystem, error) {
+	return nil, errUnsupportedPlatform
 }
 
-// WasiModule provides WASI functionality to WebAssembly modules.
-// On non-Unix platforms, WASI is not supported.
-type WasiModule struct{}
-
-func NewWasiModuleBuilder() *WasiModuleBuilder {
-	return &WasiModuleBuilder{}
+// NewHostFile reports that the syscall-based host backend is unavailable on
+// this platform.
+func NewHostFile(*os.File) (File, error) {
+	return nil, errUnsupportedPlatform
 }
-
-func (b *WasiModuleBuilder) WithArgs(args ...string) *WasiModuleBuilder {
-	return b
-}
-
-func (b *WasiModuleBuilder) WithEnv(key, value string) *WasiModuleBuilder {
-	return b
-}
-
-func (b *WasiModuleBuilder) WithEnvMap(
-	env map[string]string,
-) *WasiModuleBuilder {
-	return b
-}
-
-func (b *WasiModuleBuilder) WithDir(
-	guestPath string,
-	hostDir *os.File,
-) *WasiModuleBuilder {
-	b.files = append(b.files, hostDir)
-	return b
-}
-
-func (b *WasiModuleBuilder) WithDirRights(
-	guestPath string,
-	hostDir *os.File,
-	rights, rightsInheriting int64,
-) *WasiModuleBuilder {
-	b.files = append(b.files, hostDir)
-	return b
-}
-
-func (b *WasiModuleBuilder) WithStdin(f *os.File) *WasiModuleBuilder {
-	b.files = append(b.files, f)
-	return b
-}
-
-func (b *WasiModuleBuilder) WithStdout(f *os.File) *WasiModuleBuilder {
-	b.files = append(b.files, f)
-	return b
-}
-
-func (b *WasiModuleBuilder) WithStderr(f *os.File) *WasiModuleBuilder {
-	b.files = append(b.files, f)
-	return b
-}
-
-// Close releases all resources accumulated by the builder without constructing
-// a WasiModule.
-func (b *WasiModuleBuilder) Close() {
-	for _, f := range b.files {
-		f.Close()
-	}
-}
-
-// Build constructs a WasiModule from the builder configuration.
-// On non-Unix platforms, this always returns an error.
-func (b *WasiModuleBuilder) Build() (*WasiModule, error) {
-	b.Close()
-	return nil, errors.New("WASI is not supported on this platform")
-}
-
-func (w *WasiModule) ToImports() *epsilon.ModuleImports {
-	return epsilon.NewModuleImports(ModuleName)
-}
-
-func (w *WasiModule) Close() {}

--- a/wasip1/wasi_sys_unix.go
+++ b/wasip1/wasi_sys_unix.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -61,6 +62,179 @@ func init() {
 		utimeNow = -1
 		utimeOmit = -2
 	}
+}
+
+// hostFile is the default File implementation, backed by an *os.File. Its
+// methods delegate to the package's *at-syscall helpers below.
+type hostFile struct {
+	*os.File
+	// appendMode tracks whether the file was opened (or reconfigured) with
+	// O_APPEND, so WriteAt can still honor an explicit offset.
+	appendMode bool
+}
+
+// NewHostFile wraps a host *os.File as a File. It is the bridge for using
+// process streams (e.g. os.Stdin) or other host files with the builder's
+// backend-agnostic WithStdin/WithStdout/WithStderr methods.
+func NewHostFile(f *os.File) (File, error) {
+	return &hostFile{File: f}, nil
+}
+
+func (f *hostFile) WriteAt(p []byte, off int64) (int, error) {
+	return writeAt(f.File, p, off, f.appendMode)
+}
+
+func (f *hostFile) FileStat() (FileStat, error) {
+	return fdstat(f.File)
+}
+
+func (f *hostFile) SetFlags(appendFlag, nonblock bool) error {
+	var fdFlags int32
+	if appendFlag {
+		fdFlags |= int32(fdFlagsAppend)
+	}
+	if nonblock {
+		fdFlags |= int32(fdFlagsNonblock)
+	}
+	if err := setFdFlags(f.File, fdFlags); err != nil {
+		return err
+	}
+	f.appendMode = appendFlag
+	return nil
+}
+
+func (f *hostFile) SetTimes(atim, mtim int64, fstFlags int32) error {
+	return utimesNanoAt(f.File, atim, mtim, fstFlags)
+}
+
+func (f *hostFile) Accept() (File, error) {
+	nfd, err := accept(f.File)
+	if err != nil {
+		return nil, err
+	}
+	return &hostFile{File: os.NewFile(uintptr(nfd), "")}, nil
+}
+
+func (f *hostFile) Shutdown(how int32) error {
+	return shutdown(f.File, how)
+}
+
+// hostFileSystem is the default FileSystem implementation. It is rooted at an
+// open directory handle and resolves every path relative to it with the
+// *at-syscall helpers below, which never escape the sandbox: ".." is traversed
+// at runtime and symlinks are resolved within the root (see resolvePath).
+type hostFileSystem struct {
+	handle *hostFile // the directory's own open handle (the sandbox root)
+}
+
+// OpenHostFileSystem opens dir as a sandboxed FileSystem. Subsequent
+// operations are confined to that directory tree.
+func OpenHostFileSystem(dir string) (FileSystem, error) {
+	f, err := os.OpenFile(dir, os.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &hostFileSystem{handle: &hostFile{File: f}}, nil
+}
+
+// dir returns the directory handle every path is resolved relative to.
+func (h *hostFileSystem) dir() *os.File { return h.handle.File }
+
+func (h *hostFileSystem) Open(name string) (fs.File, error) {
+	f, err := openat(h.dir(), name, true, 0, 0, uint64(RightsFdRead))
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (h *hostFileSystem) Handle() File { return h.handle }
+
+func (h *hostFileSystem) Close() error { return h.handle.Close() }
+
+func (h *hostFileSystem) OpenFile(
+	name string,
+	followSymlink bool,
+	oflags, fdflags int32,
+	rights uint64,
+) (File, error) {
+	f, err := openat(h.dir(), name, followSymlink, oflags, fdflags, rights)
+	if err != nil {
+		return nil, err
+	}
+	appendMode := fdflags&int32(fdFlagsAppend) != 0
+	return &hostFile{File: f, appendMode: appendMode}, nil
+}
+
+func (h *hostFileSystem) OpenRoot(name string) (FileSystem, error) {
+	f, err := openat(
+		h.dir(), name, true, int32(oFlagsDirectory), 0, uint64(RightsFdRead),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &hostFileSystem{handle: &hostFile{File: f}}, nil
+}
+
+func (h *hostFileSystem) Mkdir(name string, perm fs.FileMode) error {
+	return mkdirat(h.dir(), name, uint32(perm))
+}
+
+func (h *hostFileSystem) Stat(name string, followSymlink bool) (FileStat, error) {
+	return stat(h.dir(), name, followSymlink)
+}
+
+func (h *hostFileSystem) Readlink(name string) (string, error) {
+	return readlink(h.dir(), name)
+}
+
+func (h *hostFileSystem) Symlink(target, name string) error {
+	return symlinkat(target, h.dir(), name)
+}
+
+func (h *hostFileSystem) Unlink(name string) error {
+	return unlinkat(h.dir(), name)
+}
+
+func (h *hostFileSystem) Rmdir(name string) error {
+	return rmdirat(h.dir(), name)
+}
+
+func (h *hostFileSystem) Rename(
+	newDir FileSystem,
+	oldName, newName string,
+) error {
+	target, ok := newDir.(*hostFileSystem)
+	if !ok {
+		return syscall.EXDEV
+	}
+	return renameat(h.dir(), oldName, target.dir(), newName)
+}
+
+func (h *hostFileSystem) Link(
+	oldName string,
+	followSymlink bool,
+	newDir FileSystem,
+	newName string,
+) error {
+	target, ok := newDir.(*hostFileSystem)
+	if !ok {
+		return syscall.EXDEV
+	}
+	return linkat(h.dir(), oldName, followSymlink, target.dir(), newName)
+}
+
+func (h *hostFileSystem) Chtimes(
+	name string,
+	atim, mtim int64,
+	fstFlags int32,
+	followSymlink bool,
+) error {
+	return utimes(h.dir(), name, atim, mtim, fstFlags, followSymlink)
+}
+
+func (h *hostFileSystem) ReadDir() ([]DirEntry, error) {
+	return readDirEntries(h.dir())
 }
 
 // mkdirat creates a directory relative to a directory.
@@ -107,10 +281,10 @@ func mkdirat(dir *os.File, path string, mode uint32) error {
 //   - followSymlinks: whether to follow final symlink
 //
 // Returns the filestat and an error if the operation fails.
-func stat(dir *os.File, path string, followSymlinks bool) (filestat, error) {
+func stat(dir *os.File, path string, followSymlinks bool) (FileStat, error) {
 	dirFd, fileName, err := resolvePath(dir, path, followSymlinks, 0)
 	if err != nil {
-		return filestat{}, err
+		return FileStat{}, err
 	}
 	if dirFd != int(dir.Fd()) {
 		defer unix.Close(dirFd)
@@ -119,16 +293,16 @@ func stat(dir *os.File, path string, followSymlinks bool) (filestat, error) {
 	var statBuf unix.Stat_t
 	flags := unix.AT_SYMLINK_NOFOLLOW
 	if err := unix.Fstatat(dirFd, fileName, &statBuf, flags); err != nil {
-		return filestat{}, err
+		return FileStat{}, err
 	}
 	return statFromUnix(&statBuf), nil
 }
 
 // fdstat returns a filestat from a file.
-func fdstat(file *os.File) (filestat, error) {
+func fdstat(file *os.File) (FileStat, error) {
 	var stat unix.Stat_t
 	if err := unix.Fstat(int(file.Fd()), &stat); err != nil {
-		return filestat{}, err
+		return FileStat{}, err
 	}
 	return statFromUnix(&stat), nil
 }
@@ -140,7 +314,7 @@ func fdstat(file *os.File) (filestat, error) {
 // For each entry, the inode is obtained via Fstatat. The "." entry uses the
 // directory's own inode; ".." uses inode 0 because we cannot safely access
 // the parent directory due to sandboxing.
-func readDirEntries(dir *os.File) ([]dirEntry, error) {
+func readDirEntries(dir *os.File) ([]DirEntry, error) {
 	// Get the directory's own inode for "."
 	var dirStat unix.Stat_t
 	if err := unix.Fstat(int(dir.Fd()), &dirStat); err != nil {
@@ -157,11 +331,11 @@ func readDirEntries(dir *os.File) ([]dirEntry, error) {
 		return nil, err
 	}
 
-	result := make([]dirEntry, 0, len(entries)+2)
+	result := make([]DirEntry, 0, len(entries)+2)
 	result = append(
 		result,
-		dirEntry{name: ".", fileType: int8(fileTypeDirectory), ino: dirStat.Ino},
-		dirEntry{name: "..", fileType: int8(fileTypeDirectory), ino: 0},
+		DirEntry{Name: ".", FileType: FileTypeDirectory, Ino: dirStat.Ino},
+		DirEntry{Name: "..", FileType: FileTypeDirectory, Ino: 0},
 	)
 
 	dirFd := int(dir.Fd())
@@ -172,10 +346,10 @@ func readDirEntries(dir *os.File) ([]dirEntry, error) {
 			return nil, err
 		}
 
-		result = append(result, dirEntry{
-			name:     entry.Name(),
-			fileType: fileTypeFromMode(uint32(statBuf.Mode)),
-			ino:      statBuf.Ino,
+		result = append(result, DirEntry{
+			Name:     entry.Name(),
+			FileType: fileTypeFromMode(uint32(statBuf.Mode)),
+			Ino:      statBuf.Ino,
 		})
 	}
 
@@ -815,36 +989,36 @@ func resolvePath(
 }
 
 // statFromUnix converts a unix.Stat_t to a filestat.
-func statFromUnix(s *unix.Stat_t) filestat {
-	return filestat{
-		dev:      uint64(s.Dev),
-		ino:      s.Ino,
-		filetype: fileTypeFromMode(uint32(s.Mode)),
-		nlink:    uint64(s.Nlink),
-		size:     uint64(s.Size),
-		atim:     uint64(unix.TimespecToNsec(s.Atim)),
-		mtim:     uint64(unix.TimespecToNsec(s.Mtim)),
-		ctim:     uint64(unix.TimespecToNsec(s.Ctim)),
+func statFromUnix(s *unix.Stat_t) FileStat {
+	return FileStat{
+		Dev:      uint64(s.Dev),
+		Ino:      s.Ino,
+		FileType: fileTypeFromMode(uint32(s.Mode)),
+		Nlink:    uint64(s.Nlink),
+		Size:     uint64(s.Size),
+		Atim:     uint64(unix.TimespecToNsec(s.Atim)),
+		Mtim:     uint64(unix.TimespecToNsec(s.Mtim)),
+		Ctim:     uint64(unix.TimespecToNsec(s.Ctim)),
 	}
 }
 
 // fileTypeFromMode extracts the WASI file type from a Unix mode.
-func fileTypeFromMode(mode uint32) int8 {
+func fileTypeFromMode(mode uint32) FileType {
 	switch mode & unix.S_IFMT {
 	case unix.S_IFBLK:
-		return int8(fileTypeBlockDevice)
+		return FileTypeBlockDevice
 	case unix.S_IFCHR:
-		return int8(fileTypeCharacterDevice)
+		return FileTypeCharacterDevice
 	case unix.S_IFDIR:
-		return int8(fileTypeDirectory)
+		return FileTypeDirectory
 	case unix.S_IFREG:
-		return int8(fileTypeRegularFile)
+		return FileTypeRegularFile
 	case unix.S_IFSOCK:
-		return int8(fileTypeSocketStream)
+		return FileTypeSocketStream
 	case unix.S_IFLNK:
-		return int8(fileTypeSymbolicLink)
+		return FileTypeSymbolicLink
 	default:
-		return int8(fileTypeUnknown)
+		return FileTypeUnknown
 	}
 }
 
@@ -876,46 +1050,4 @@ func buildTimespec(atim, mtim int64, fstFlags int32) ([]unix.Timespec, error) {
 	}
 
 	return []unix.Timespec{atimSpec, mtimSpec}, nil
-}
-
-// mapError maps Go/Syscall errors to WASI errno.
-func mapError(err error) int32 {
-	if unwrapped := errors.Unwrap(err); unwrapped != nil {
-		err = unwrapped
-	}
-
-	if errno, ok := err.(syscall.Errno); ok {
-		switch errno {
-		case syscall.EACCES:
-			return errnoAcces
-		case syscall.EPERM:
-			return errnoPerm
-		case syscall.ENOENT:
-			return errnoNoEnt
-		case syscall.EEXIST:
-			return errnoExist
-		case syscall.EISDIR:
-			return errnoIsDir
-		case syscall.ENOTDIR:
-			return errnoNotDir
-		case syscall.EINVAL:
-			return errnoInval
-		case syscall.ENOTEMPTY:
-			return errnoNotEmpty
-		case syscall.ELOOP:
-			return errnoLoop
-		case syscall.EBADF:
-			return errnoBadF
-		case syscall.EMFILE, syscall.ENFILE:
-			return errnoNFile
-		case syscall.ENAMETOOLONG:
-			return errnoNameTooLong
-		case syscall.EPIPE:
-			return errnoPipe
-		case syscall.EAGAIN:
-			return errnoAgain
-		}
-	}
-
-	return errnoNotCapable
 }

--- a/wasip1/wasi_sys_unix_test.go
+++ b/wasip1/wasi_sys_unix_test.go
@@ -85,6 +85,20 @@ func testFS(t *testing.T, entries ...fsEntry) (string, *os.File) {
 	return root, dirFd
 }
 
+// testHostFS creates a filesystem structure for testing and returns the root
+// path and a FileSystem rooted there, closed automatically when the test ends.
+func testHostFS(t *testing.T, entries ...fsEntry) (string, FileSystem) {
+	t.Helper()
+	root, dirFd := testFS(t, entries...)
+	dirFd.Close() // OpenHostFileSystem opens its own root handle.
+	fsys, err := OpenHostFileSystem(root)
+	if err != nil {
+		t.Fatalf("OpenHostFileSystem failed: %v", err)
+	}
+	t.Cleanup(func() { fsys.Close() })
+	return root, fsys
+}
+
 func TestOpenat_BasicFile(t *testing.T) {
 	_, dirFd := testFS(t, file("test.txt", "hello"))
 	defer dirFd.Close()
@@ -532,11 +546,11 @@ func TestStat_BasicFile(t *testing.T) {
 		t.Fatalf("stat failed: %v", err)
 	}
 
-	if fs.filetype != int8(fileTypeRegularFile) {
-		t.Errorf("expected regular file, got filetype %d", fs.filetype)
+	if fs.FileType != FileTypeRegularFile {
+		t.Errorf("expected regular file, got filetype %d", fs.FileType)
 	}
-	if fs.size != 5 {
-		t.Errorf("expected size 5, got %d", fs.size)
+	if fs.Size != 5 {
+		t.Errorf("expected size 5, got %d", fs.Size)
 	}
 }
 
@@ -549,8 +563,8 @@ func TestStat_Directory(t *testing.T) {
 		t.Fatalf("stat failed: %v", err)
 	}
 
-	if fs.filetype != int8(fileTypeDirectory) {
-		t.Errorf("expected directory, got filetype %d", fs.filetype)
+	if fs.FileType != FileTypeDirectory {
+		t.Errorf("expected directory, got filetype %d", fs.FileType)
 	}
 }
 
@@ -563,8 +577,8 @@ func TestStat_CurrentDir(t *testing.T) {
 		t.Fatalf("stat . failed: %v", err)
 	}
 
-	if fs.filetype != int8(fileTypeDirectory) {
-		t.Errorf("expected directory, got filetype %d", fs.filetype)
+	if fs.FileType != FileTypeDirectory {
+		t.Errorf("expected directory, got filetype %d", fs.FileType)
 	}
 }
 
@@ -577,8 +591,8 @@ func TestStat_NestedPath(t *testing.T) {
 		t.Fatalf("stat nested failed: %v", err)
 	}
 
-	if fs.filetype != int8(fileTypeRegularFile) {
-		t.Errorf("expected regular file, got filetype %d", fs.filetype)
+	if fs.FileType != FileTypeRegularFile {
+		t.Errorf("expected regular file, got filetype %d", fs.FileType)
 	}
 }
 
@@ -594,8 +608,8 @@ func TestStat_SymlinkNoFollow(t *testing.T) {
 		t.Fatalf("stat symlink failed: %v", err)
 	}
 
-	if fs.filetype != int8(fileTypeSymbolicLink) {
-		t.Errorf("expected symbolic link, got filetype %d", fs.filetype)
+	if fs.FileType != FileTypeSymbolicLink {
+		t.Errorf("expected symbolic link, got filetype %d", fs.FileType)
 	}
 }
 
@@ -611,11 +625,11 @@ func TestStat_SymlinkFollow(t *testing.T) {
 		t.Fatalf("stat symlink with follow failed: %v", err)
 	}
 
-	if fs.filetype != int8(fileTypeRegularFile) {
-		t.Errorf("expected regular file, got filetype %d", fs.filetype)
+	if fs.FileType != FileTypeRegularFile {
+		t.Errorf("expected regular file, got filetype %d", fs.FileType)
 	}
-	if fs.size != 7 {
-		t.Errorf("expected size 7, got %d", fs.size)
+	if fs.Size != 7 {
+		t.Errorf("expected size 7, got %d", fs.Size)
 	}
 }
 
@@ -745,8 +759,8 @@ func TestStat_IntermediateSymlinkAllowed(t *testing.T) {
 		t.Fatalf("stat through intermediate symlink failed: %v", err)
 	}
 
-	if fs.filetype != int8(fileTypeRegularFile) {
-		t.Errorf("expected regular file, got filetype %d", fs.filetype)
+	if fs.FileType != FileTypeRegularFile {
+		t.Errorf("expected regular file, got filetype %d", fs.FileType)
 	}
 }
 

--- a/wasip1/wasi_types.go
+++ b/wasip1/wasi_types.go
@@ -16,8 +16,11 @@ package wasip1
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
-	"os"
+	"io"
+	"io/fs"
+	"syscall"
 )
 
 // ProcExitError is an error that signals that the process should exit with the
@@ -85,13 +88,13 @@ const (
 	RightsSockAccept           int64 = 1 << 29
 )
 
-// WasiPreopen represents a pre-opened os.File to be provided to WASI.
+// WasiPreopen represents a pre-opened FileSystem to be provided to WASI as a
+// directory capability mounted at GuestPath.
 //
-// If the WasiModule is successfully created, it takes ownership of the File and
-// will close it when appropriate. If creation fails, ownership stays with the
-// caller.
+// The WasiModule (or builder) takes ownership of FS and closes it when
+// appropriate.
 type WasiPreopen struct {
-	File             *os.File
+	FS               FileSystem
 	GuestPath        string
 	Rights           int64
 	RightsInheriting int64
@@ -122,15 +125,18 @@ const (
 	errnoNotCapable  int32 = 76 // Extension: Capabilities insufficient.
 )
 
+// FileType is a WASI Preview 1 filetype, as reported in FileStat and DirEntry.
+type FileType uint8
+
 const (
-	fileTypeUnknown         uint8 = 0
-	fileTypeBlockDevice     uint8 = 1
-	fileTypeCharacterDevice uint8 = 2
-	fileTypeDirectory       uint8 = 3
-	fileTypeRegularFile     uint8 = 4
-	fileTypeSocketDgram     uint8 = 5
-	fileTypeSocketStream    uint8 = 6
-	fileTypeSymbolicLink    uint8 = 7
+	FileTypeUnknown         FileType = 0
+	FileTypeBlockDevice     FileType = 1
+	FileTypeCharacterDevice FileType = 2
+	FileTypeDirectory       FileType = 3
+	FileTypeRegularFile     FileType = 4
+	FileTypeSocketDgram     FileType = 5
+	FileTypeSocketStream    FileType = 6
+	FileTypeSymbolicLink    FileType = 7
 )
 
 const preopenTypeDir uint8 = 0
@@ -171,49 +177,181 @@ const (
 
 const lookupFlagsSymlinkFollow int32 = 1 << 0
 
-// dirEntry represents a directory entry for fd_readdir.
-type dirEntry struct {
-	name     string
-	fileType int8
-	ino      uint64
+// DirEntry is a single directory entry returned by FileSystem.ReadDir, which is
+// expected to include the synthetic "." and ".." entries required by
+// fd_readdir.
+type DirEntry struct {
+	Name     string
+	FileType FileType
+	Ino      uint64
 }
 
-// bytes serializes the dirEntry to the WASI dirent layout.
+// bytes serializes the DirEntry to the WASI dirent layout.
 // The nextCookie parameter is the cookie for the next entry in the directory.
-func (d *dirEntry) bytes(nextCookie uint64) []byte {
-	nameLen := len(d.name)
+func (d *DirEntry) bytes(nextCookie uint64) []byte {
+	nameLen := len(d.Name)
 	buf := make([]byte, 24+nameLen)
 	binary.LittleEndian.PutUint64(buf[0:8], nextCookie)
-	binary.LittleEndian.PutUint64(buf[8:16], d.ino)
+	binary.LittleEndian.PutUint64(buf[8:16], d.Ino)
 	binary.LittleEndian.PutUint32(buf[16:20], uint32(nameLen))
-	buf[20] = uint8(d.fileType)
-	copy(buf[24:], d.name)
+	buf[20] = uint8(d.FileType)
+	copy(buf[24:], d.Name)
 	return buf
 }
 
-// filestat represents the WASI filestat structure (64 bytes total).
-type filestat struct {
-	dev      uint64 // offset 0:  device ID
-	ino      uint64 // offset 8:  inode
-	filetype int8   // offset 16: file type (1 byte, 7 padding)
-	nlink    uint64 // offset 24: number of hard links
-	size     uint64 // offset 32: file size in bytes
-	atim     uint64 // offset 40: access time (nanoseconds)
-	mtim     uint64 // offset 48: modification time (nanoseconds)
-	ctim     uint64 // offset 56: status change time (nanoseconds)
+// FileStat is the WASI FileStat structure (64 bytes when serialized). Times are
+// nanoseconds since the Unix epoch.
+type FileStat struct {
+	Dev      uint64   // device ID
+	Ino      uint64   // inode
+	FileType FileType // file type
+	Nlink    uint64   // number of hard links
+	Size     uint64   // file size in bytes
+	Atim     uint64   // access time
+	Mtim     uint64   // modification time
+	Ctim     uint64   // status change time
 }
 
-// bytes serializes the filestat to the WASI memory layout (64 bytes).
-func (fs *filestat) bytes() [64]byte {
+// bytes serializes the FileStat to the WASI memory layout (64 bytes).
+func (fs *FileStat) bytes() [64]byte {
 	var buf [64]byte
-	binary.LittleEndian.PutUint64(buf[0:8], fs.dev)
-	binary.LittleEndian.PutUint64(buf[8:16], fs.ino)
-	buf[16] = uint8(fs.filetype)
+	binary.LittleEndian.PutUint64(buf[0:8], fs.Dev)
+	binary.LittleEndian.PutUint64(buf[8:16], fs.Ino)
+	buf[16] = uint8(fs.FileType)
 	// buf[17:24] padding (already zero)
-	binary.LittleEndian.PutUint64(buf[24:32], fs.nlink)
-	binary.LittleEndian.PutUint64(buf[32:40], fs.size)
-	binary.LittleEndian.PutUint64(buf[40:48], fs.atim)
-	binary.LittleEndian.PutUint64(buf[48:56], fs.mtim)
-	binary.LittleEndian.PutUint64(buf[56:64], fs.ctim)
+	binary.LittleEndian.PutUint64(buf[24:32], fs.Nlink)
+	binary.LittleEndian.PutUint64(buf[32:40], fs.Size)
+	binary.LittleEndian.PutUint64(buf[40:48], fs.Atim)
+	binary.LittleEndian.PutUint64(buf[48:56], fs.Mtim)
+	binary.LittleEndian.PutUint64(buf[56:64], fs.Ctim)
 	return buf
+}
+
+// File is an open file, directory, or socket handle used by the WASI
+// implementation. It extends the read-only io/fs.File with the write, seek,
+// and metadata operations WASI requires. The default implementation
+// (hostFileSystem) is backed by *os.File; alternative backends may provide
+// virtualized or in-memory handles.
+type File interface {
+	fs.File // Stat() (fs.FileInfo, error); Read([]byte) (int, error); Close() error
+	io.Writer
+	io.Seeker
+	io.ReaderAt
+	io.WriterAt
+
+	Truncate(size int64) error
+	Sync() error
+
+	// FileStat returns the metadata of the open handle (fd_filestat_get).
+	FileStat() (FileStat, error)
+	// SetFlags updates the O_APPEND/O_NONBLOCK status flags of the open handle
+	// (fd_fdstat_set_flags).
+	SetFlags(appendFlag, nonblock bool) error
+	// SetTimes sets the access/modification times of the open handle
+	// (fd_filestat_set_times). atim and mtim are nanoseconds; fstFlags selects
+	// which times to set and how.
+	SetTimes(atim, mtim int64, fstFlags int32) error
+
+	// Accept accepts a connection on a socket handle (sock_accept).
+	Accept() (File, error)
+	// Shutdown shuts down a socket handle (sock_shutdown).
+	Shutdown(how int32) error
+}
+
+// FileSystem is a sandboxed, directory-rooted view of a filesystem. Every name
+// is resolved relative to the root and may never escape it, mirroring the WASI
+// directory-capability model where each directory descriptor is its own root.
+// The default host implementation resolves every path relative to the root
+// using *at syscalls, providing traversal-resistant ("..") and symlink-escape
+// protections.
+type FileSystem interface {
+	fs.FS // Open(name string) (fs.File, error)
+
+	// OpenFile opens a regular file within the root. followSymlink controls
+	// whether a symlink in the final path component is followed.
+	OpenFile(name string, followSymlink bool, oflags, fdflags int32, rights uint64) (File, error)
+	// OpenRoot opens a subdirectory as a new sandboxed FileSystem.
+	OpenRoot(name string) (FileSystem, error)
+
+	Mkdir(name string, perm fs.FileMode) error
+	// Stat returns the metadata of name. followSymlink controls whether a
+	// symlink in the final path component is followed.
+	Stat(name string, followSymlink bool) (FileStat, error)
+	Readlink(name string) (string, error)
+	Symlink(target, name string) error
+	// Unlink removes a non-directory entry (EISDIR on a directory).
+	Unlink(name string) error
+	// Rmdir removes an empty directory (ENOTDIR on a non-directory).
+	Rmdir(name string) error
+	Rename(newDir FileSystem, oldName, newName string) error
+	Link(oldName string, followSymlink bool, newDir FileSystem, newName string) error
+	// Chtimes sets the access/modification times of name. followSymlink controls
+	// whether a symlink in the final path component is followed.
+	Chtimes(name string, atim, mtim int64, fstFlags int32, followSymlink bool) error
+	// ReadDir reads the entries of the root directory, including the synthetic
+	// "." and ".." entries required by fd_readdir.
+	ReadDir() ([]DirEntry, error)
+
+	// Handle returns the directory's own open handle, used for fd-level
+	// operations (fd_fdstat_get, fd_readdir, fd_filestat_get, fd_sync).
+	Handle() File
+	Close() error
+}
+
+// mapError maps Go, io/fs, and syscall errors to a WASI errno.
+func mapError(err error) int32 {
+	if err == nil {
+		return errnoSuccess
+	}
+
+	// Match the specific syscall.Errno before the broader io/fs sentinels:
+	// syscall.Errno.Is maps several distinct errnos onto the same fs sentinel
+	// (e.g. both EEXIST and ENOTEMPTY satisfy fs.ErrExist), which would
+	// otherwise lose the distinction WASI requires.
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.EACCES:
+			return errnoAcces
+		case syscall.EPERM:
+			return errnoPerm
+		case syscall.ENOENT:
+			return errnoNoEnt
+		case syscall.EEXIST:
+			return errnoExist
+		case syscall.EISDIR:
+			return errnoIsDir
+		case syscall.ENOTDIR:
+			return errnoNotDir
+		case syscall.EINVAL:
+			return errnoInval
+		case syscall.ENOTEMPTY:
+			return errnoNotEmpty
+		case syscall.ELOOP:
+			return errnoLoop
+		case syscall.EBADF:
+			return errnoBadF
+		case syscall.EMFILE, syscall.ENFILE:
+			return errnoNFile
+		case syscall.ENAMETOOLONG:
+			return errnoNameTooLong
+		case syscall.EPIPE:
+			return errnoPipe
+		case syscall.EAGAIN:
+			return errnoAgain
+		}
+	}
+
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return errnoNoEnt
+	case errors.Is(err, fs.ErrExist):
+		return errnoExist
+	case errors.Is(err, fs.ErrPermission):
+		return errnoAcces
+	case errors.Is(err, fs.ErrInvalid):
+		return errnoInval
+	}
+
+	return errnoNotCapable
 }


### PR DESCRIPTION
Introduce FileSystem and File interfaces (wasi_types.go) so the WASI state machine is decoupled from the host OS and callers can supply their own backend (e.g. an in-memory filesystem) via WithFS.

Closes #75